### PR TITLE
revnews: Git mailing list is not only for developers

### DIFF
--- a/rev_news/draft/edition-1.md
+++ b/rev_news/draft/edition-1.md
@@ -6,7 +6,7 @@ a monthly digest of all things Git, written collaboratively
 on [GitHub](https://github.com/git/git.github.io) by volunteers. 
 
 Our goal is to aggregate and communicate
-the activities on the [Git developers' mailing list](mailto:git@vger.kernel.org)
+the activities on the [Git mailing list](mailto:git@vger.kernel.org)
 in a format that the wider tech community can follow
 and understand. In addition, we'll link to all the interesting Git-related
 articles, tools and projects we come across.


### PR DESCRIPTION
http://git.github.io/rev_news/rev_news.html calls the list "Git
mailng list"; be consistent and welcoming to non developers.