### PR TITLE
revnews: remove meaningless "X also reviewed"

### DIFF
--- a/rev_news/draft/edition-1.md
+++ b/rev_news/draft/edition-1.md
@@ -89,8 +89,6 @@ they do, add a failing test that passes again once you uncomment the
 code.
 ```
 
-Junio also reviewed some parts of the patch.
-
 * [Forbid "log --graph --no-walk"](http://thread.gmane.org/gmane.comp.version-control.git/264899/)
 
 Dongcan Jiang, who will also probably apply to be a GSoC student for


### PR DESCRIPTION
The fact that the patch was reviewed by the maintainer does not add
much value to the section by itself. It is a different matter if it
were accompanied by a summary of value the review added to the
discussion, but otherwise it only makes the section longer without
adding much value ot the reader.