### PR TITLE
revnews: be explicit about the date range

### DIFF
--- a/rev_news/draft/edition-1.md
+++ b/rev_news/draft/edition-1.md
@@ -11,6 +11,8 @@ in a format that the wider tech community can follow
 and understand. In addition, we'll link to all the interesting Git-related
 articles, tools and projects we come across.
 
+This edition covers what happened during the month of March 2015.
+
 Tips us or contribute news by sending [pull
 requests](https://github.com/git/git.github.io/pulls) or opening
 [issues](https://github.com/git/git.github.io/issues).


### PR DESCRIPTION
The oldest topic covered in the current writing is $gmane/264899
"log --graph --no-walk" from early March.  By being explicit about
the earliest date, set the expectation of readers to avoid possible
complaints e.g. "why isn't that topic that is a lot more interesting
covered here?"