### PR TITLE
Mention David Kastrup in "Promoting Git developers"

### DIFF
--- a/rev_news/draft/edition-1.md
+++ b/rev_news/draft/edition-1.md
@@ -23,7 +23,8 @@ requests](https://github.com/git/git.github.io/pulls) or opening
 
 * [Promoting Git developers](http://thread.gmane.org/gmane.comp.version-control.git/265165)
 
-In a discussion started by Christian Couder, Michael J Gruber noted
+Following up to a message from David Kastrup, a discussion was initiated
+by Christian Couder where Michael J Gruber noted
 that there are three classes of Git developers, and it is hard for
 people who are not already sponsored by corporations to work on Git
 not as a hobbyist, but as a means to gain either monetarily or build


### PR DESCRIPTION
My feeling reading the list is that the discussion leading to this rev news was actually initiated by David Kastrup's message, hence he should be the one to credit here (even though his message insisted more on the problem than on solutions).