### PR TITLE
rev_news: redirect rev_news/ to current edition

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 name: Git Developer Pages
 markdown: redcarpet
+gems:
+  - jekyll-redirect-from

--- a/rev_news/edition-1.md
+++ b/rev_news/edition-1.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Git Rev News Edition 1 (March 25th, 2015)
+redirect_from: "/rev_news/"
 ---
 
 ## Git Rev News: Edition 1 (March 25th, 2015)


### PR DESCRIPTION
This makes https://git.github.io/rev_news/ do something sensible (as opposed to giving a 404). An obvious alternative would be to just have an index page that links to the editions in reverse chronological order.

This `redirect_from` will need to be updated manually as new editions are published.

Fixes #34.
