### PR TITLE
rev-news: fixup quote regarding regressions from Junio

### DIFF
--- a/rev_news/edition-2.md
+++ b/rev_news/edition-2.md
@@ -194,10 +194,8 @@ working on making Git fast for big repositories.
 * [First release candidate for Git 2.4](http://git-blame.blogspot.de/2015/04/first-release-candidate-for-git-24.html),
   April 2nd.
 
-Paraphrasing Junio,  
-please test it thoroughly so that we can ship a successful v2.4 final at
-the end of the month without the regressions we experienced in the v2.3
-series.
+Paraphrasing Junio, please test it thoroughly so that we can ship a successful v2.4 final at
+the end of the month without any regressions with respect to v2.3.
 
 * [Git 2.3.5 for Windows Release Candidate 8](https://github.com/git-for-windows/git/releases/tag/v2.3.5.windows.8),
   April 10th.


### PR DESCRIPTION
In paraphrasing a quote in 3bfd3a01054d3448aefdc148c3bb5e7a579935de, we lost the original meaning. There weren't regressions in v2.3; the original was trying to say that we care about making sure we don't have regressions since v2.3. Hopefully this paraphrase makes that more clear.

/cc @gitster @emmajane