### PR TITLE
rn-7: fix partly broken link to youtube

### DIFF
--- a/_posts/2015-09-09-edition-7.markdown
+++ b/_posts/2015-09-09-edition-7.markdown
@@ -385,7 +385,7 @@ __Light reading__
   interactive tutorial.
 * [Blinking Commits](http://blog.annharter.com/2015/08/12/blinking-commits.html),
   if you ever needed a blinking commit message.
-* A YouTube celebrity called "Day[9]" recently took some minutes to [explain Git](https://www.youtube.com/watch?v=CPAIBmtH9xQ&feature=youtu.be&t=131://www.youtube.com/watch?v=CPAIBmtH9xQ&feature=youtu.be&t=1311) on his popular gaming channel.
+* A YouTube celebrity called "Day[9]" recently took some minutes to [explain Git](https://www.youtube.com/watch?v=CPAIBmtH9xQ&t=21m51s) on his popular gaming channel.
 
 __Git tools and sites__
 


### PR DESCRIPTION
The original link is „doubled“ (probably a copy-paste error), so that youtube isn’t able to parse the timing part and starts the video at the beginning. So let us:

- remove the repetition,
- remove the reference to the not used youtu.be link shortener,
- and, as much as we all like the metric system, `21m51s` is more readable as `1311`.