### PR TITLE
soc-2016-ideas: adjust markdown for "whitelist" example

### DIFF
--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -291,18 +291,18 @@ and blacklist using Git config.
 Whitelist example:
 ```
 [remote]
-    default = deny
-    message = "Are you sure you're not pushing company code?"
-    allowed = http://whitelisted-hosting.org
-    allowed = http://git-hosting.org/whitelisted-org
-    allowed = http://git-hosting.org/org/whitelisted-repo
+default = deny
+message = "Are you sure you're not pushing company code?"
+allowed = http://whitelisted-hosting.org
+allowed = http://git-hosting.org/whitelisted-org
+allowed = http://git-hosting.org/org/whitelisted-repo
 ```
 
 Blacklist example:
 ```
 [remote]
-    default = allow    
-    denied = http://denied-hosting.com
+default = allow
+denied = http://denied-hosting.com
 ```
 
 If a user wants to push changes to a blacklisted remote then the `push`

--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -289,6 +289,7 @@ This project is about to implement a Git remote whitelist
 and blacklist using Git config.
 
 Whitelist example:
+
 ```
 [remote]
     default = deny
@@ -299,6 +300,7 @@ Whitelist example:
 ```
 
 Blacklist example:
+
 ```
 [remote]
     default = allow    

--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -291,18 +291,18 @@ and blacklist using Git config.
 Whitelist example:
 ```
 [remote]
-default = deny
-message = "Are you sure you're not pushing company code?"
-allowed = http://whitelisted-hosting.org
-allowed = http://git-hosting.org/whitelisted-org
-allowed = http://git-hosting.org/org/whitelisted-repo
+    default = deny
+    message = "Are you sure you're not pushing company code?"
+    allowed = http://whitelisted-hosting.org
+    allowed = http://git-hosting.org/whitelisted-org
+    allowed = http://git-hosting.org/org/whitelisted-repo
 ```
 
 Blacklist example:
 ```
 [remote]
-default = allow
-denied = http://denied-hosting.com
+    default = allow    
+    denied = http://denied-hosting.com
 ```
 
 If a user wants to push changes to a blacklisted remote then the `push`


### PR DESCRIPTION
GitHub's markdown seems to render this as one big jumble, rather than as a `<pre>`-formatted block.

I'm not really sure _why_, but dropping the indentation seems to fix it.