### PR TITLE
add Outreachy page for May 2016

### DIFF
--- a/Outreachy-2016-May.md
+++ b/Outreachy-2016-May.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Outreachy May 2016
+---
+
+# Outreachy May 2016
+
+Git is participating in Round 12 of Outreachy, an internship program to
+encourage diversity in Free and Open Source Software projects. You can
+find out more about the program at its [homepage](https://www.gnome.org/outreachy/).
+
+This is the landing page for Git's participation in Round 12 of
+Outreachy, which will run from May 23, 2016 to August 23, 2016.  Note
+that Git is also participating in Google Summer of Code during the same
+period. Eligible individuals may apply for both programs (see this
+[FAQ](https://wiki.gnome.org/action/show/Outreachy?action=show&redirect=OutreachProgramForWomen#Is_Google_Summer_of_Code_right_for_you.3F)
+for details.
+
+## How to Apply
+
+The deadline for applying to Outreachy is **March 22** at 7pm UTC.
+Before then, you should fill out an
+[application](https://wiki.gnome.org/OutreachProgramForWomen#Send_in_an_Application)
+and complete a small [coding
+project](https://wiki.gnome.org/action/show/Outreachy?action=show&redirect=OutreachProgramForWomen#Make_a_Small_Contribution).
+We have a list of
+[microprojects](../SoC-2016-Microprojects), but
+you may also work with a potential mentor to come up with a contribution
+related to your proposed project.
+
+## Project Ideas
+
+You can find a list of project ideas on our [ideas
+page](../SoC-2016-Ideas). Note that this just a list of suggested
+projects; we are happy to hear proposals for new projects. If you're not
+sure whether your idea is workable, please feel free to solicit feedback
+from the mailing list (see below).
+
+## Getting in Touch
+
+Most git development happens on the mailing list. Details for posting,
+subscribing, and reading archives can be found on our [community
+page](http://git-scm.com/community).
+
+You can also find people on the #git channel of irc.freenode.net.


### PR DESCRIPTION
This is a program similar to GSoC, but which may increase the range of applicants we get (specifically it allows non-students, but the applicants must be from an under-represented group).

Logistics-wise, it reuses most of the existing resources we've developed for GSoC (and in fact, candidates may just end up applying via GSoC if they qualify there).

I'm planning to merge this right away, as we're already halfway through the Outreachy application period, and I want to get this up ASAP. But comments, corrections, and reverts are welcome. :)
