### PR TITLE
SoC-2016-Ideas: tell that we accept at most 2 students

### DIFF
--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -94,7 +94,7 @@ discussions.)
 ## Note about the number of slots
 
 In 2016, the Git organization has very limited mentoring capacity.
-We will probably be able to accept 2 students only this year.
+These days we usually accept between 0 and 2 students per year.
 
 ## Summer of code main project ideas
 


### PR DESCRIPTION
I am sending this for next year.

It feels more honest to say that we usually accept at most 2 students these days, than to suggest that we will accept at least 2 students.