### PR TITLE
convert all internal links to https

### DIFF
--- a/SoC-2014-Ideas.md
+++ b/SoC-2014-Ideas.md
@@ -11,7 +11,7 @@ This is the idea page for Summer of Code 2014 for Git and libgit2.
 It is strongly recommended that students who want to apply to the Git
 project for the Summer of Code 2014 complete a tiny, code-related
 "microproject" as part of their application.  Please refer to our
-[guidelines and suggestions for microprojects](http://git.github.io/SoC-2014-Microprojects.html)
+[guidelines and suggestions for microprojects](https://git.github.io/SoC-2014-Microprojects.html)
 for more information.  Completing a microproject is not a strict
 requirement, but we will definitely give more attention to applicants
 who do so.  Doing a microproject will also help get you started in

--- a/SoC-2014-Org-Application.md
+++ b/SoC-2014-Org-Application.md
@@ -35,7 +35,7 @@ GPLv2
 
 ## Ideas list
 
-<http://git.github.io/SoC-2014-Ideas.html>
+<https://git.github.io/SoC-2014-Ideas.html>
 
 ## Mailing list
 

--- a/SoC-2015-Ideas.md
+++ b/SoC-2015-Ideas.md
@@ -10,7 +10,7 @@ This is the idea page for Summer of Code 2015 for Git and libgit2.
 It is required that students who want to apply to the Git
 project for the Summer of Code 2015 complete a tiny, code-related
 "microproject" as part of their application.  Please refer to our
-[guidelines and suggestions for microprojects](http://git.github.io/SoC-2015-Microprojects.html)
+[guidelines and suggestions for microprojects](https://git.github.io/SoC-2015-Microprojects.html)
 for more information. Completing a microproject is not only an important
 way for us to get experience with applicants, but it will also help
 applicants become familiar with Git's development and submission

--- a/SoC-2015-Org-Application.md
+++ b/SoC-2015-Org-Application.md
@@ -34,7 +34,7 @@ GPLv2
 
 ## Ideas list
 
-<http://git.github.io/SoC-2015-Ideas.html>
+<https://git.github.io/SoC-2015-Ideas.html>
 
 ## Mailing list
 

--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -13,7 +13,7 @@ This is the idea page for Summer of Code 2016 for Git and libgit2.
 It is required that students who want to apply to the Git
 project for the Summer of Code 2016 complete a tiny, code-related
 "microproject" as part of their application.  Please refer to our
-[guidelines and suggestions for microprojects](http://git.github.io/SoC-2016-Microprojects)
+[guidelines and suggestions for microprojects](https://git.github.io/SoC-2016-Microprojects)
 for more information. Completing a microproject is not only an important
 way for us to get experience with applicants, but it will also help
 applicants become familiar with Git's development and submission
@@ -54,7 +54,7 @@ discussion.
 
 Getting your proposal right can follow the same process as usual patch
 submission for Git, as described in the
-[microprojects](http://git.github.io/SoC-2016-Microprojects) page and
+[microprojects](https://git.github.io/SoC-2016-Microprojects) page and
 in `Documentation/SubmittingPatches` in Git's source code. It is also
 expected that you will send several versions of your draft, responding
 to comments on the list. If you are not sure about your proposal, you
@@ -63,7 +63,7 @@ separate emails. Please use "[GSoC]" at the beginning of such emails.
 
 In summary, all applicants must (not necessarily in this order):
 
-* Complete a [microproject](http://git.github.io/SoC-2016-Microprojects).
+* Complete a [microproject](https://git.github.io/SoC-2016-Microprojects).
 
 * Write a detailed application explaining their project.
 

--- a/SoC-2016-Org-Application.md
+++ b/SoC-2016-Org-Application.md
@@ -37,7 +37,7 @@ version control, dvcs
 
 ## Ideas List
 
-<http://git.github.io/SoC-2016-Ideas/>
+<https://git.github.io/SoC-2016-Ideas/>
 
 ## Short Description (180 chars max)
 
@@ -69,7 +69,7 @@ template or tips for their proposals. May include limited Markdown.
 ```
 
 Please read the "About applying for SoC with the Git project" section
-in the ideas page: http://git.github.io/SoC-2016-Ideas/
+in the ideas page: https://git.github.io/SoC-2016-Ideas/
 
 The primary way to contact the Git community is through the Git
 mailing list git@vger.kernel.org. Please discuss your application on

--- a/_posts/2015-03-25-edition-1.markdown
+++ b/_posts/2015-03-25-edition-1.markdown
@@ -8,7 +8,7 @@ categories: [news]
 
 ## Git Rev News: Edition 1 (March 25th, 2015)
 
-Welcome to the first edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the first edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git, written collaboratively 
 on [GitHub](https://github.com/git/git.github.io) by volunteers. 
 
@@ -55,7 +55,7 @@ Git this year, anticipated the start of the GSoC and sent a patch to
 rewrite git-pull.sh as a built-in.
 
 Indeed as stated in [the GSoC idea
-page](http://git.github.io/SoC-2015-Ideas.html):
+page](https://git.github.io/SoC-2015-Ideas.html):
 
 
 > Many components of Git are still in the form of shell and Perl
@@ -117,7 +117,7 @@ Dongcan Jiang, who will also probably apply to be a GSoC student for
 Git this year, sent a patch to prevent `git log` from being used with both
 the `--graph` and the `--no-walk` option. He sent this patch because
 the Git community asks potential students to work on a
-[microproject](http://git.github.io/SoC-2015-Microprojects.html) to
+[microproject](https://git.github.io/SoC-2015-Microprojects.html) to
 make sure that they can work properly with the community.
 
 Eric Sunshine made some good general suggestions that are often made

--- a/_posts/2015-04-15-edition-2.markdown
+++ b/_posts/2015-04-15-edition-2.markdown
@@ -8,7 +8,7 @@ navbar: false
 ---
 ## Git Rev News: Edition 2 (April 15, 2015), 10 years of Git & Git Merge 2015!
 
-Welcome to the second edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the second edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git, written collaboratively
 on [GitHub](https://github.com/git/git.github.io) by volunteers.
 

--- a/_posts/2015-05-13-edition-3.markdown
+++ b/_posts/2015-05-13-edition-3.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 3 (May 13, 2015)
 
-Welcome to the third edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the third edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, how to contribute or to
-subscribe see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on http://git.github.io.
+subscribe see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on https://git.github.io.
 
 This edition still covers Git's 10th year of existence, as well as the
 [Git Merge](http://git-merge.com) conference held on April 8th & 9th in Paris,

--- a/_posts/2015-06-03-edition-4.markdown
+++ b/_posts/2015-06-03-edition-4.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 4 (June 3rd, 2015)
 
-Welcome to the fourth edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the fourth edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of May 2015.
 

--- a/_posts/2015-07-08-edition-5.markdown
+++ b/_posts/2015-07-08-edition-5.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 5 (July 8th, 2015)
 
-Welcome to the fifth edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the fifth edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of June 2015.
 

--- a/_posts/2015-08-05-edition-6.markdown
+++ b/_posts/2015-08-05-edition-6.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 6 (August 5th, 2015)
 
-Welcome to the sixth edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the sixth edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of July 2015.
 
@@ -253,7 +253,7 @@ community that we set out to be, we need your help.
 
 So please, the next time you read through an interesting discussion on
 the mailing list, note down a few lines about it and
-[share them with us](http://git.github.io/rev_news/rev_news/).
+[share them with us](https://git.github.io/rev_news/rev_news/).
 
 ----
 

--- a/_posts/2015-09-09-edition-7.markdown
+++ b/_posts/2015-09-09-edition-7.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 7 (September 9th, 2015)
 
-Welcome to the 7th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 7th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of August 2015.
 
@@ -123,7 +123,7 @@ effect if it breaks is.
 Reading the students proposals and resume is rarely sufficient to
 really evaluate their skills, which makes the risk particularly hard
 to evaluate. Since 2014, we've been using
-[microprojects](http://git.github.io/SoC-2015-Microprojects.html) to
+[microprojects](https://git.github.io/SoC-2015-Microprojects.html) to
 select students. This turned out to be very efficient, both at
 identifying good (or bad) applicants, but also at giving students a
 glimpse of what "contributing to Git" means. Student get an idea of

--- a/_posts/2015-10-14-edition-8.markdown
+++ b/_posts/2015-10-14-edition-8.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 8 (October 14th, 2015)
 
-Welcome to the 8th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 8th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of September 2015.
 
@@ -239,7 +239,7 @@ I only found this recently, it's just brilliant. Thank you, whoever it was put t
 
 __Updates__
 
-* [Since we talked about it last month](http://git.github.io/rev_news/2015/09/09/edition-7/) David Turner
+* [Since we talked about it last month](https://git.github.io/rev_news/2015/09/09/edition-7/) David Turner
 submitted [a new patch series](http://thread.gmane.org/gmane.comp.version-control.git/278757) of his work on
 alternate ref backends. This work is being reviewed by Michael Haggerty, Junio, and others. The ultimate goal 
 is still to allow a lmdb-based backend, which should be faster and have fewer issues on

--- a/_posts/2015-11-11-edition-9.markdown
+++ b/_posts/2015-11-11-edition-9.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 9 (November 11th, 2015)
 
-Welcome to the 9th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 9th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of October 2015.
 

--- a/_posts/2015-12-09-edition-10.markdown
+++ b/_posts/2015-12-09-edition-10.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 10 (December 9th, 2015)
 
-Welcome to the 10th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 10th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of November 2015.
 

--- a/_posts/2016-01-13-edition-11.markdown
+++ b/_posts/2016-01-13-edition-11.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 11 (January 13th, 2016)
 
-Welcome to the 11th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 11th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of December 2015.
 

--- a/_posts/2016-02-10-edition-12.markdown
+++ b/_posts/2016-02-10-edition-12.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 12 (February 10th, 2016)
 
-Welcome to the 12th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 12th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of January 2016.
 
@@ -35,7 +35,7 @@ work to add a database backend to store Git refs:
 
 This work was started a long time ago by Ronnie Sahlberg, working for
 Google, and has already been reported about in
-[Git Rev News edition 7](http://git.github.io/rev_news/2015/09/09/edition-7/).
+[Git Rev News edition 7](https://git.github.io/rev_news/2015/09/09/edition-7/).
 
 These last patch series have again been reviewed or commented on by a
 lot of experienced Git developers, like Junio Hamano, Michael

--- a/_posts/2016-03-16-edition-13.markdown
+++ b/_posts/2016-03-16-edition-13.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 13 (March 16th, 2016)
 
-Welcome to the 13th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 13th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of February 2016.
 

--- a/_posts/2016-04-20-edition-14.markdown
+++ b/_posts/2016-04-20-edition-14.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 14 (April 20th, 2016)
 
-Welcome to the 14th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 14th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of March 2016 and
 also what happened at the Git Contributor Summit on April 4 2016 and
@@ -53,8 +53,8 @@ going on to implement additional ref backends, especially a
 [lmdb](http://symas.com/mdb/) based one.
 
 (This work on an lmdb based ref backend has been reported on in
-[Git Rev News edition 12](http://git.github.io/rev_news/2016/02/10/edition-12/) and
-[Git Rev News edition 7](http://git.github.io/rev_news/2015/09/09/edition-7/).)
+[Git Rev News edition 12](https://git.github.io/rev_news/2016/02/10/edition-12/) and
+[Git Rev News edition 7](https://git.github.io/rev_news/2015/09/09/edition-7/).)
 
 From there the discussion switched to the case sensitiveness of ref
 names, and the different problems created by having ref names that

--- a/_posts/2016-05-11-edition-15.markdown
+++ b/_posts/2016-05-11-edition-15.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 15 (May 11th, 2016)
 
-Welcome to the 15th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 15th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of April 2016,
 especially at the Git Contributor Summit on April 4 2016 and at the
@@ -23,7 +23,7 @@ Git Merge conference on April 5 2016.
 
 * Discussions at the Git Contributor Summit, part 2, about misc topics
 
-*Read part 1 in [Git Rev News Edition 14](http://git.github.io/rev_news/2016/04/20/edition-14/)* 
+*Read part 1 in [Git Rev News Edition 14](https://git.github.io/rev_news/2016/04/20/edition-14/)* 
 
 At the Git Contributor Summit on April 4th, just after the lunch
 break, the state of the participation of the Git project in the Google

--- a/feed.xml
+++ b/feed.xml
@@ -14,8 +14,8 @@ navbar: false
   >
   <channel>
     <title xml:lang="en">Git Rev News</title>
-    <atom:link type="application/atom+xml" href="http://git.github.io/feed.xml" rel="self"/>
-    <link>http://git.github.io/rev_news/</link>
+    <atom:link type="application/atom+xml" href="https://git.github.io/feed.xml" rel="self"/>
+    <link>https://git.github.io/rev_news/</link>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <language>en-US</language>
@@ -25,14 +25,14 @@ navbar: false
       <description>Git Rev News</description>
       <url>http://jekyllrb.com/img/logo-rss.png</url>
       <title>Git Rev News</title>
-      <link>http://git.github.io/rev_news/</link>
+      <link>https://git.github.io/rev_news/</link>
       <width>144</width>
       <height>73</height>
     </image>
     {% for post in site.posts %}
     <item>
       <title>{{ post.title | xml_escape}}</title>
-      <link>http://git.github.io{{ post.url }}</link>
+      <link>https://git.github.io{{ post.url }}</link>
       <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
       <dc:creator>{{ post.author }}</dc:creator>
       {% for tag in post.tags %}
@@ -41,7 +41,7 @@ navbar: false
       {% for cat in post.categories %}
       <category>{{ cat | xml_escape }}</category>
       {% endfor %}
-      <guid isPermaLink="true">http://git.github.io{{ post.url }}</guid>
+      <guid isPermaLink="true">https://git.github.io{{ post.url }}</guid>
       <description>{{ post.content | xml_escape }}</description>
     </item>
     {% endfor %}

--- a/rev_news/drafts/edition-16.md
+++ b/rev_news/drafts/edition-16.md
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 16 (XXX, 2016)
 
-Welcome to the 16th edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the 16th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](https://git.github.io).
 
 This edition covers what happened during the month of May 2016.
 

--- a/rev_news/edition-1.md
+++ b/rev_news/edition-1.md
@@ -7,7 +7,7 @@ navbar: false
 ## Git Rev News: Edition 1 (March 25th, 2015)
 
 
-Welcome to the first edition of [Git Rev News](http://git.github.io/rev_news/rev_news/),
+Welcome to the first edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git, written collaboratively 
 on [GitHub](https://github.com/git/git.github.io) by volunteers. 
 
@@ -54,7 +54,7 @@ Git this year, anticipated the start of the GSoC and sent a patch to
 rewrite git-pull.sh as a built-in.
 
 Indeed as stated in [the GSoC idea
-page](http://git.github.io/SoC-2015-Ideas.html):
+page](https://git.github.io/SoC-2015-Ideas.html):
 
 ```
 Many components of Git are still in the form of shell and Perl
@@ -122,7 +122,7 @@ Dongcan Jiang, who will also probably apply to be a GSoC student for
 Git this year, sent a patch to prevent `git log` from being used with both
 the `--graph` and the `--no-walk` option. He sent this patch because
 the Git community asks potential students to work on a
-[microproject](http://git.github.io/SoC-2015-Microprojects.html) to
+[microproject](https://git.github.io/SoC-2015-Microprojects.html) to
 make sure that they can work properly with the community.
 
 Eric Sunshine made some good general suggestions that are often made


### PR DESCRIPTION
Now that GitHub Pages can use https (and we'll be upgrading http requests to https), we can use https links everywhere to avoid the upgrade step.

This is a purely mechanical conversion.

I do wonder if some of these could be relative links (they are all referring to the git.github.io site itself), but here I've taken the most conservative route.

/cc @git/web 