### PR TITLE
Fix broken `Git Rev News page` links in Git Rev news

### DIFF
--- a/_posts/2016-07-20-edition-17.markdown
+++ b/_posts/2016-07-20-edition-17.markdown
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 17 (July 20th, 2016)
 
-Welcome to the 17th edition of [Git Rev News](http://git.github.io/rev_news/rev_news.html),
+Welcome to the 17th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news.html) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
 
 This edition covers what happened during the month of June 2016.
 

--- a/rev_news/drafts/edition-18.md
+++ b/rev_news/drafts/edition-18.md
@@ -9,9 +9,9 @@ navbar: false
 
 ## Git Rev News: Edition 18 (XXX, 2016)
 
-Welcome to the 18th edition of [Git Rev News](http://git.github.io/rev_news/rev_news.html),
+Welcome to the 18th edition of [Git Rev News](https://git.github.io/rev_news/rev_news/),
 a digest of all things Git. For our goals, the archives, the way we work, and how to contribute or to
-subscribe, see [the Git Rev News page](http://git.github.io/rev_news/rev_news.html) on [git.github.io](http://git.github.io).
+subscribe, see [the Git Rev News page](https://git.github.io/rev_news/rev_news/) on [git.github.io](http://git.github.io).
 
 This edition covers what happened during the month of July 2016.
 


### PR DESCRIPTION
A few of those old `rev_news.html` links made it through... (after  https://github.com/git/git.github.io/issues/157). Also using HTTPS for preference.