### PR TITLE
Expand info about Gmane web interface shutting down

### DIFF
--- a/rev_news/drafts/edition-18.md
+++ b/rev_news/drafts/edition-18.md
@@ -224,7 +224,7 @@ __Light reading__
 __Git tools and sites__
 
 * Gmane (a mailing list archive that was used heavily by some Git developers)
-[shut down its web site](https://lars.ingebrigtsen.no/2016/07/28/the-end-of-gmane/comment-page-1/#comment-13502).
+[shut down its web site](https://lars.ingebrigtsen.no/2016/07/28/the-end-of-gmane/comment-page-1/#comment-13502).  This issue was covered in the ["Ingebrigtsen: The End of Gmane?"](https://lwn.net/Articles/695695/) short note on LWN.net, which got included in the  ["Announcements" section of LWN.net Weekly Edition for August 4, 2016](http://lwn.net/Articles/695980/); comments there mention that threaded view in Gmane web interface had no equal in other mail archive sites.  There is also [Alternatives to mid.gmane.org?](https://public-inbox.org/git/%3C481D1EE2-6A66-418F-AB28-95947BBF3680@gmail.com%3E/) thread, listing among others [MARC.info](https://marc.info/?l=git) and public-inbox.  [A note from the maintainer](https://public-inbox.org/git/%3Cxmqq1t1twymf.fsf@gitster.mtv.corp.google.com%3E/) got updated in light of this change.
 * [public-inbox](https://public-inbox.org/), which is under heavy developement by Eric Wong, has
 [a git archive](https://public-inbox.org/git/) that is now used a lot instead of Gmane.
 [It allows](https://public-inbox.org/design_www.html) looking up


### PR DESCRIPTION
Based on my replies to _"Draft of Git Rev News edition 18"_ thread:

  * Message-Id: [9f3b254f-451e-4f6d-233c-7e995d8e369e@gmail.com](https://public-inbox.org/git/9f3b254f-451e-4f6d-233c-7e995d8e369e@gmail.com)
  * Message-Id: [6b492c8c-2c75-9258-03dc-78346c98ff69@gmail.com](https://public-inbox.org/git/6b492c8c-2c75-9258-03dc-78346c98ff69@gmail.com)

as requested by Christian Couder

  * Message-Id: [CAP8UFD24QpuOOh1b3LCbnuF-0TSJC7E34mjvqo3zdebb_spNxw@mail.gmail.com](https://public-inbox.org/git/CAP8UFD24QpuOOh1b3LCbnuF-0TSJC7E34mjvqo3zdebb_spNxw@mail.gmail.com)