### PR TITLE
Link "see our emails" in help request

### DIFF
--- a/rev_news/drafts/edition-19.md
+++ b/rev_news/drafts/edition-19.md
@@ -276,7 +276,7 @@ people to join our small Git Rev News editor team.
 
 There is no need to even know Git well for that. It's possible to
 participate by just proofreading articles for example. Please contact
-us (see our emails at the bottom) if you are interested.
+us (see our emails [at the bottom](#credits)) if you are interested.
 
 
 ### Reviews


### PR DESCRIPTION
Minor issue: make 'at the bottom' link to the bottom of page, or rather the anchor for "Credits" header at bottom.