### PR TITLE
rn20: Git User's Survey 2016 ends soon

### DIFF
--- a/rev_news/drafts/edition-20.md
+++ b/rev_news/drafts/edition-20.md
@@ -200,6 +200,10 @@ platforms and looking simple to users.
 
 ## Other News
 
+__Events__
+
+* [Git User's Survey 2016](https://survs.com/survey/3cop1kt5eg) ends soon, on 20 October 2016
+
 __Various__
 
 * Here is [git-test-repository: A Git repository full of special cases, for testing purposes](https://github.com/book/git-test-repository) - very handy when you're testing out a new Git GUI or repository manager.


### PR DESCRIPTION
Just a reminder for those who have not answered yet.

The "Git User's Survey 2016" is to end at 20 October 2016... one day after Git Rev News edition 20 is planned to come out.