### PR TITLE
Fix 404 on About in Navbar

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,7 @@
 <div id="navbar" class="navbar">
   <ul>
     <li><a href="/">Home</a>
-    <li><a href="/about.html">About</a>
+    <li><a href="/about">About</a>
     {% for node in site.pages reversed %}
       {% if node.navbar != false %}
       <li><a href="{{node.url}}">{{node.title}}</a>


### PR DESCRIPTION
Currently "about" in navigation bar is a 404. This is a fix - now it renders `about.md` as expected.