### PR TITLE
soc-2017 typographical fixups

### DIFF
--- a/SoC-2017-Ideas.md
+++ b/SoC-2017-Ideas.md
@@ -117,7 +117,7 @@ When your project is strictly "new features are merged into trunk,
 never the other way around", it is handy to be able to first find
 a merge on the trunk that merged a topic to point fingers at when
 a bug appears, instead of having to drill down to the individual
-commit on the faulty side branch. Cf.  <http://thread.gmane.org/gmane.comp.version-control.git/264661/focus=264720>
+commit on the faulty side branch. Cf.  <http://public-inbox.org/git/20150304053333.GA9584@peff.net/>
 
 #### Fix some git bisect bugs
 

--- a/SoC-2017-Microprojects.md
+++ b/SoC-2017-Microprojects.md
@@ -144,6 +144,7 @@ This project requires a very good knowledge of regular expressions.
 ### Make "`git tag --contains <id>`" less chatty if `<id>` is invalid
 
 `git tag --contains <id>` prints the whole help text if `<id>` is invalid.
+It should only show the error message instead. [[thread](https://public-inbox.org/git/20160118215433.GB24136@sigill.intra.peff.net)]
 
 ### Git CI Improvements 1
 
@@ -208,14 +209,14 @@ for example.
 Pick one command that operates on branch names.  Teach it the "-"
 shorthand that stands for "the branch we were previously on", like we
 did for "git merge -" sometime after we introduced "git checkout -".
-Cf. $gmane/230828
+[[thread](https://public-inbox.org/git/7vppuewl6h.fsf@alter.siamese.dyndns.org)]
 
 ### Use unsigned integral type for collection of bits.
 
 Pick one field of a structure that (1) is of signed integral type and (2) is
 used as a collection of multiple bits. Discuss if there is a good reason
 why it has to be a signed integral field and change it to an unsigned
-type otherwise.  Cf. $gmane/263751
+type otherwise.  [[thread](https://public-inbox.org/git/xmqqsiebrlez.fsf@gitster.dls.corp.google.com)]
 
 ### Move `~/.git-credential-cache` to `~/.cache/git`
 

--- a/SoC-2017-Microprojects.md
+++ b/SoC-2017-Microprojects.md
@@ -218,15 +218,16 @@ used as a collection of multiple bits. Discuss if there is a good reason
 why it has to be a signed integral field and change it to an unsigned
 type otherwise.  Cf. $gmane/263751
 
-### Move ~/.git-credential-cache to ~/.cache/git
+### Move `~/.git-credential-cache` to `~/.cache/git`
 
 Most of git dotfiles can be located, at the user's option, in
-~/.<file> or in ~/.config/git/<file>, following the
+`~/.<file>` or in `~/.config/git/<file>`, following the
 [XDG standard](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-~/.git-credential-cache is still hardcoded as ~/.git-credential-cache,
+`~/.git-credential-cache` is still hardcoded as
+`~/.git-credential-cache`,
 but should allow using the XDG directory layout too as
-~/.cache/git/credential, possibly modified by $XDG_CONFIG_HOME and
-$XDG_CACHE_HOME).
+`~/.cache/git/credential`, possibly modified by `$XDG_CONFIG_HOME` and
+`$XDG_CACHE_HOME`).
 
 The suggested approach is:
 

--- a/SoC-2017-Microprojects.md
+++ b/SoC-2017-Microprojects.md
@@ -32,7 +32,7 @@ reviews and discussions. If you are not sure at all about a patch you can
 put "[RFC/PATCH]" at the beginning of its subject.
 
 Consider [a sample email
-thread](http://thread.gmane.org/gmane.comp.version-control.git/239068),
+thread](http://public-inbox.org/git/1386590745-4412-1-git-send-email-t.gummerer@gmail.com/T/#u),
 which shows how a developer proposed a change and a patch to implement
 it.  The problem being solved, the design of the proposed solution,
 and the implementation of that design were all reviewed and discussed,

--- a/SoC-2017-Microprojects.md
+++ b/SoC-2017-Microprojects.md
@@ -141,10 +141,9 @@ example, shell.
 
 This project requires a very good knowledge of regular expressions.
 
-### Make "`git tag --contains <id>`" less chatty if <id> is invalid
+### Make "`git tag --contains <id>`" less chatty if `<id>` is invalid
 
-git tag `--contains` <id> prints the whole help text if <id> is invalid.
-It should only show the error message instead. Cf. $gmane/284328
+`git tag --contains <id>` prints the whole help text if `<id>` is invalid.
 
 ### Git CI Improvements 1
 


### PR DESCRIPTION
This is a mixed bag of typographical fixups, along with converting references to gmane to point to public-inbox instead. I only bothered with the 2017 pages, as the older ones are basically historical. We should perhaps consider removing them from the navigation bar on the side (we could also remove them completely, but perhaps people would want to refer to them? They'd always be available in the history, of course).
