### PR TITLE
navbar fixups

### DIFF
--- a/Outreachy-2016-May.md
+++ b/Outreachy-2016-May.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Outreachy May 2016
+navbar: false
 ---
 
 # Outreachy May 2016

--- a/SoC-2015-Ideas.md
+++ b/SoC-2015-Ideas.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2015 Ideas
+navbar: false
 ---
 
 This is the idea page for Summer of Code 2015 for Git and libgit2.

--- a/SoC-2015-Microprojects.md
+++ b/SoC-2015-Microprojects.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2015 Applicant Microprojects
+navbar: false
 ---
 
 ## Introduction

--- a/SoC-2015-Org-Application.md
+++ b/SoC-2015-Org-Application.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2015 Organization Application
+navbar: false
 ---
 
 This is a draft of git's application to Google's Summer of Code 2015.

--- a/SoC-2016-Ideas.md
+++ b/SoC-2016-Ideas.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2016 Ideas
+navbar: false
 ---
 
 This is the idea page for Summer of Code 2016 for Git and libgit2.

--- a/SoC-2016-Microprojects.md
+++ b/SoC-2016-Microprojects.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2016 Applicant Microprojects
+navbar: false
 ---
 
 ## Introduction

--- a/SoC-2016-Org-Application.md
+++ b/SoC-2016-Org-Application.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2016 Organization Application
+navbar: false
 ---
 
 This is a draft of git's application to Google's Summer of Code 2016.

--- a/SoC-Historical.md
+++ b/SoC-Historical.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Historical Summer of Code Materials
+---
+
+These pages are historical application materials for Summer of Code and
+other programs. They are for reference only!
+
+<ul>
+{% for node in site.pages reversed %}
+  {% if node.navbar == false %}
+    {% if node.title contains "SoC" or node.title contains "Outreachy" %}
+      <li><a href="{{node.url}}">{{node.title}}</a>
+    {% endif %}
+  {% endif %}
+{% endfor %}

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -3,7 +3,7 @@
     <li><a href="/">Home</a>
     <li><a href="/about">About</a>
     {% for node in site.pages reversed %}
-      {% if node.navbar != false %}
+      {% if node.navbar != false and node.title != "" %}
       <li><a href="{{node.url}}">{{node.title}}</a>
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
This tries to de-bloat the navbar a bit by moving historical summer of code materials to their own page. It also fixes a bug in our navbar generation which caused a blank entry.