### PR TITLE
rn-24: Add a few links about Git Merge 2017 event

### DIFF
--- a/rev_news/drafts/edition-24.md
+++ b/rev_news/drafts/edition-24.md
@@ -108,6 +108,12 @@ Anything that makes textconv fly (unoconv, pdftotext); tig when
 
 ## Other News
 
+__Events__
+* [Git Merge 2017 recap](https://github.com/blog/2317-git-merge-2017-recap) on GitHub Blog
+* [We’ll be at Git Merge 2017!](https://blog.bitbucket.org/2017/02/01/well-git-merge-2017/) on Bitbucket Blog
+* [Report from Git Merge 2017](http://www.praqma.com/stories/work-on-git-merge-2017/) by Lars Kruse, _Praqma_
+* [Git Merge 2017 – what you missed](https://blog.recast.ai/git-merge-2017/) on Recast.AI Blog
+
 __Various__
 
 


### PR DESCRIPTION
Git Merge 2017 was on February 2-3, 2017 in Brussels, Belgium.
Hopefully there would be more reports.