### PR TITLE
"Previous branch" is too big for microproject

### DIFF
--- a/SoC-2017-Microprojects.md
+++ b/SoC-2017-Microprojects.md
@@ -202,12 +202,6 @@ See the commit
 [c6f44e1da5](https://github.com/git/git/commit/c6f44e1da5e88e34)
 for example.
 
-### Allow "-" as a short-hand for "@{-1}" in more places.
-
-Pick one command that operates on branch names.  Teach it the "-"
-shorthand that stands for "the branch we were previously on", like we
-did for "git merge -" sometime after we introduced "git checkout -".
-[[thread](https://public-inbox.org/git/7vppuewl6h.fsf@alter.siamese.dyndns.org)]
 
 ### Use unsigned integral type for collection of bits.
 


### PR DESCRIPTION
As I said in the review of Kannan's attempt in https://public-inbox.org/git/xmqqtw882n08.fsf@gitster.mtv.corp.google.com/, this is not a suitable topic for a micro-project, as doing it in a "micro" way adds more problems than it solves, and doing it correctly (which Kannan's attempt is a step in the right direction) is way more than a "micro".

Let's remove this.