### PR TITLE
Gerrit User Summit 2017 registration link

### DIFF
--- a/rev_news/drafts/edition-28.md
+++ b/rev_news/drafts/edition-28.md
@@ -219,6 +219,7 @@ doesn't look like much has been done to implement them yet.
 
 __Various__
 
+* [Gerrit User Summit 2017 registration is now open](https://gerritusersummit.eventbrite.com) and is hosted for the first time in Europe, London, 2-3rd October 2017.
 
 __Light reading__
 


### PR DESCRIPTION
Add link to the Gerrit User Summit 2017 (formerly GitTogether) registration page.