### PR TITLE
rn-28: Add more places with inline code style - formatting fixes and improvements

### DIFF
--- a/_posts/2017-06-14-edition-28.markdown
+++ b/_posts/2017-06-14-edition-28.markdown
@@ -56,7 +56,7 @@ John then described in more details the previous behavior:
 
 > We have a parent repo on a branch called "develop" and a submodule on
 > a branch called "master". Prior to git version 2.13 if we had an
-> unpushed commit in the submodule and ran `git push origin develop --recurse-submodules=on-demand"
+> unpushed commit in the submodule and ran `git push origin develop --recurse-submodules=on-demand`
 > git would happily push the "develop" branch of the parent repo and the
 > "master" branch of the submodule
 
@@ -70,7 +70,7 @@ and the new one:
 Brandon replied that:
 
 > Yeah my patches would definitely break that kind of workflow because
-> they assumed that if you actually provided a refspec + --recurse that
+> they assumed that if you actually provided a refspec + `--recurse` that
 > you would want it propagated down.
 
 Jonathan Nieder then replied to John's original email by explaining in
@@ -99,19 +99,23 @@ much happened, so recently John replied to his own mail:
 > are. I'm happy to send a patch but I would like to get a consensus
 > first.
 
-* [git rebase regression: cannot pass a shell expression directly to --exec](http://public-inbox.org/git/CA+zRj8X3OoejQVhUHD9wvv60jpTEZy06qa0y7TtodfBa1q5bnA@mail.gmail.com/)
+* [git rebase regression: cannot pass a shell expression directly to `--exec`](http://public-inbox.org/git/CA+zRj8X3OoejQVhUHD9wvv60jpTEZy06qa0y7TtodfBa1q5bnA@mail.gmail.com/)
 
 Eric Rannaud emailed the mailing list:
 
 > It used to be possible to run a sequence like:
 >
+> ``` sh
 >   foo() { echo X; }
 >   export -f foo
 >   git rebase --exec foo HEAD~10
+> ```
 >
 > Since upgrading to 2.13.0, I had to update my scripts to run:
 >
+> ``` sh
 >   git rebase --exec "bash -c foo" HEAD~10
+> ```
 
 Eric had bisected this to a commit that switched
 [the interactive rebase to use the rebase--helper builtin](https://github.com/git/git/commit/18633e1a22a68bbe8e6311a1039d13ebbf6fd041).
@@ -130,7 +134,7 @@ shell code from "git-rebase--interactive.sh" to C.
 
 Jeff King, alias Peff, replied to Eric that a `git rebase --exec STRING`
 command still uses a shell to run STRING, but that the behavior change
-may come from an optimization that was made in the prepare_shell_cmd()
+may come from an optimization that was made in the `prepare_shell_cmd()`
 function in "run-command.c" to skip shell invocations for "simple"
 commands.
 
@@ -139,13 +143,13 @@ to confirm that the problem comes from the optimization, as, with a
 semi-colon in it, the STRING part would not be considered a "simple"
 command.
 
-Peff then explained that the optimization in prepare_shell_cmd() is
+Peff then explained that the optimization in `prepare_shell_cmd()` is
 quite old, but it affects `git rebase --exec` only now because it is
 now using C code. And this optimization fails only when people are
 using exported functions which is not so common, as not all shells
 support them.
 
-Peff also suggested, and later sent a patch, to look for BASH_FUNC_*
+Peff also suggested, and later sent a patch, to look for `BASH_FUNC_*`
 in the environment and disable the optimization in this case, though
 that wouldn't work in all cases.
 
@@ -184,12 +188,12 @@ Eric then replied to Peff to "clarify if there was any doubt, the
 semicolon trick does indeed work fine". He also asked for consistency
 writing that with an exported foo function the current behavior was:
 
-```
-  git bisect run foo  # works
+``` console
+  git bisect run foo     # works
   git bisect run 'foo;'  # doesn't work
 
-  git rebase --exec foo master^^  # fails
-  git rebase --exec 'foo;' master^^  # OK
+  git rebase --exec foo master^^      # fails
+  git rebase --exec 'foo;' master^^   # OK
   git rebase --exec 'foo 1' master^^  # OK
 ```
 
@@ -197,7 +201,7 @@ In the meantime Jonathan Nieder, Brandon Williams and then Kevin Daudt
 chimed in to discuss with Peff and Eric a suggestion by Peff to
 "speculatively run `foo` without the shell, and if execve fails to
 find it, then fall back to running the shell". They also discussed a
-bit Peff's suggestion to look for BASH_FUNC_* in the environment, but
+bit Peff's suggestion to look for `BASH_FUNC_*` in the environment, but
 it was clear that both of these solutions had a number of problems.
 
 Then Linus Torvalds chimed in too. He suggested to just lookup in
@@ -205,7 +209,7 @@ $PATH for the first word passed in the `--exec` string, as this test
 is better than looking for special characters like semi-colons, to
 decide if we can avoid calling a shell.
 
-He also suggested using vfork() instead of fork() if we "really want
+He also suggested using `vfork()` instead of `fork()` if we "really want
 to optimize the code that executes an external program (whether in
 shell or directly)".
 
@@ -237,14 +241,14 @@ contributor, though I still love discussing Computer Architecture!
 * What would you name your most important contribution to Git?
 
 Though I haven't been around the project long I think some of my most
-important contribution has been to add submodule support to ls-files and
-grep.
+important contribution has been to add submodule support to `ls-files` and
+`grep`.
 
 * What are you doing on the Git project these days, and why?
 
 Most of my contributions (and Stefan's) are aimed at improving the
 submodule experience, which means adding submodule support to more and
-more git commands.  Adding that support to ls-files and grep was a bit
+more git commands.  Adding that support to `ls-files` and `grep` was a bit
 challenging in that our code base isn't able to handle working on more
 than 1 repository at a time, so when you want to do any operation on a
 submodule you need to kick off a child-process to do the work for you.


### PR DESCRIPTION
Use `inline code` style to avoid turning '--' (double dash) in
description of long options into '–' (long dash) ligature in few
more places.  Balance backticks.

Add block of code formatting in more places, and provide explicit
programming language name for each code block.

Align start of line comments in code blocks.