### PR TITLE
rn-38: add notes from Stefan Beller about protocol-v2

### DIFF
--- a/rev_news/drafts/edition-38.md
+++ b/rev_news/drafts/edition-38.md
@@ -255,6 +255,10 @@ Kaartic's patch series will probably also be merged there too.
   to fetch a single branch, the server still needs to send thousands of
   references as refs-advertisement. We can improve it.
 
+  (EDIT: Stefan Beller pointed out that there would be great improvements
+  in protocol v2, a simpler and less wasteful protocol, which had already
+  been merged from the bw/protocol-v2 topic branch to Git next branch.)
+
 * If you could remove something from Git without worrying about
   backwards compatibility, what would it be?
 


### PR DESCRIPTION
Notes form Stefan:

> See the branch bw/protocol-v2 which is in next, that allows for
> listing refs selectively as well as having a distinction for "end of
> list" and "I am done talking", such that proxies to be written can be
> done easier. (There is 0000 and 0001 end packets IIRC).