### PR TITLE
Add a few details about optimizing writes to unchanged files

### DIFF
--- a/rev_news/drafts/edition-39.md
+++ b/rev_news/drafts/edition-39.md
@@ -93,10 +93,11 @@ approaches.
 Elijah also replied to Linus' alternative patch by discussing
 different approaches. And Junio agreed with the direction Elijah was
 taking, though he had not as much time as he would have liked to think
-this through at that time.
+this through at that time.  Junio discussed Linus' alternative patch
+anyway with Linus, and noted that it could cause problems in the case
+of local dirty changes.
 
-Junio discussed Linus' alternative patch anyway with Linus and then
-Lars Schneider chimed in by suggesting to add a cache to speed up
+Then Lars Schneider chimed in by suggesting to add a cache to speed up
 builds. Ævar Arnfjörð Bjarmason then replied to Lars and they
 discussed this idea but concluded that it wouldn't work.
 
@@ -109,9 +110,12 @@ Phillip Wood replied to Lars by sending a Perl script he has been
 using to save and restore mtimes to avoid rebuilds.
 
 Elijah resent [his patch series](https://public-inbox.org/git/20180419175823.7946-1-newren@gmail.com/)
-a few days later, and though there were further fixes needed, it
-appears that the patch series will be merged in the "next" branch
-soon.
+a few days later, and after a few minor fixes, the patch series was
+merged to "next" on May 8.  The commit message of the final patch of
+the series in particular documents the
+["long and blemished history"](https://public-inbox.org/git/20180419175823.7946-37-newren@gmail.com/)
+of the can-working-tree-updates-be-skipped check and how it has been
+fixed.
 
 ## Developer Spotlight: Johannes Schindelin (alias Dscho)
 


### PR DESCRIPTION
In regards to the story about optimizing writes to unchanged files:

1) The text noted that en/rename-directory-detection-reboot would be
   merged to next soon (that's what the last cooking email said), but it
   has since been merged to next..
2) It's worth noting that Junio found a bug with Linus' proposed "stupid
   brute force" patch (namely that if a file involved in a rename has
   dirty changes before a merge, those dirty changes could be overwritten
   without warning to the user).
3) Finally, since there is a specific commit message that explains the
   history of the can-we-skip-worktree-updates check and what fix was
   used, link to it so the curious can dig more (without having to read
   all the patches about directory rename detection).