### PR TITLE
RevNews: do not claim that the Microsoft/GitHub deal is final

### DIFF
--- a/_posts/2018-06-20-edition-40.markdown
+++ b/_posts/2018-06-20-edition-40.markdown
@@ -21,8 +21,8 @@ This edition covers what happened during the month of May 2018.
 
 * Microsoft acquires Github for $7.5 billion
 
-On Monday, June 4th, Microsoft acquired Github for $7.5 billion in an all-stock
-deal. After [Business Insider reported on
+On Monday, June 4th, Microsoft announced an agreement to acquire GitHub for $7.5 billion in an all-stock
+deal. The acquisition is expected to close later this year. After [Business Insider reported on
 Friday](http://www.businessinsider.com/2-billion-startup-github-could-be-for-sale-microsoft-2018-5?IR=T)
 that Microsoft was in talks to acquire Github, Microsoft CEO [Satya Nadella
 made it


### PR DESCRIPTION
It has been made very clear from both Microsoft and GitHub that they announced an *agreement*. So the intent is there, but the acquisition is far from final, and therefore the companies are still independent of each other, and are still managed independently as long as the deal is closed.

We should not spread inaccurate news, so let's just state the facts correctly (otherwise this RevNews item could be misconstrued to be crafted to help competing companies by using that age-old despicable technique of spreading Fear, Uncertainty, and Doubt). There is no need to invent anything here, what I did was a slightly edited copy/paste from Satya's blog post.