### PR TITLE
Add final "Supercharging" article

### DIFF
--- a/rev_news/drafts/edition-41.md
+++ b/rev_news/drafts/edition-41.md
@@ -136,6 +136,7 @@ __Various__
   - [Supercharging the Git Commit Graph](https://blogs.msdn.microsoft.com/devops/2018/06/25/supercharging-the-git-commit-graph/)
   - [Supercharging the Git Commit Graph II: File Format](https://blogs.msdn.microsoft.com/devops/2018/07/02/supercharging-the-git-commit-graph-ii-file-format/)
   - [Supercharging the Git Commit Graph III: Generations and Graph Algorithms](https://blogs.msdn.microsoft.com/devops/2018/07/09/supercharging-the-git-commit-graph-iii-generations/)
+  - [Supercharing the Git Commit Graph IV: Bloom Filters](https://blogs.msdn.microsoft.com/devops/2018/07/16/super-charging-the-git-commit-graph-iv-bloom-filters/)
 
 __Light reading__
 


### PR DESCRIPTION
The blog series "Supercharging the Git Commit Graph" has four parts. The last was published today.

Parts III and IV cover the work that is planned for Git, so I will refer people to them as we discuss the work.