### PR TITLE
Fix SHA-1 size

### DIFF
--- a/_posts/2018-07-18-edition-41.markdown
+++ b/_posts/2018-07-18-edition-41.markdown
@@ -29,7 +29,7 @@ future steps in this area.
 
 As the new hash function is still undecided (see below), it is called
 "NewHash" by everyone for now. It is expected though that it will be a
-256-bit hash algorithm while SHA-1 is 128-bit, and this change alone
+256-bit hash algorithm while SHA-1 is 160-bit, and this change alone
 has required a lot of internal work.
 
 With Brian's latest patches Git would work using NewHash, including


### PR DESCRIPTION
A SHA-1 hash has 160 bits (40 hex digits), not 128.

---

I really hope I’m not being stupid here and missed something obvious :)