### PR TITLE
Fix gerrit release note links

### DIFF
--- a/_posts/2018-04-18-edition-38.markdown
+++ b/_posts/2018-04-18-edition-38.markdown
@@ -308,7 +308,7 @@ Kaartic's patch series will probably also be merged there, too.
 [3.5.1](https://support.gitkraken.com/release-notes/current#v3-5-1)
 * libgit2 [0.27.0-rc3](https://github.com/libgit2/libgit2/releases/tag/v0.27.0-rc3) and
 [0.27.0](https://github.com/libgit2/libgit2/releases/tag/v0.27.0)
-* Gerrit Code Review [2.5.1](https://www.gerritcodereview.com/releases/2.15.md)
+* Gerrit Code Review [2.15.1](https://www.gerritcodereview.com/2.15.html#2151)
 
 ## Other News
 

--- a/_posts/2018-07-18-edition-41.markdown
+++ b/_posts/2018-07-18-edition-41.markdown
@@ -122,7 +122,7 @@ has been made.
 + GitHub Desktop [v1.2.6](https://desktop.github.com/release-notes/),
 [v1.2.5](https://desktop.github.com/release-notes/),
 [v1.2.4](https://desktop.github.com/release-notes/)
-+ Gerrit Code Review [v2.14.10](https://www.gerritcodereview.com/releases/2.14.md)
++ Gerrit Code Review [v2.14.10](https://www.gerritcodereview.com/2.14.html#21410)
 + Git Tower GUI v2: [Better than Ever: The New Tower Has Launched](https://www.git-tower.com/blog/the-new-tower-has-launched-2018), now with annual license model
 
 ## Other News

--- a/_posts/2018-08-22-edition-42.markdown
+++ b/_posts/2018-08-22-edition-42.markdown
@@ -215,7 +215,7 @@ It looks like the latest version will be merged to the "next" branch soon.
 ## Releases
 
 + libgit2 [v0.27.4](https://github.com/libgit2/libgit2/releases/tag/v0.27.4)
-+ Gerrit Code Review [v2.15.3](https://www.gerritcodereview.com/releases/2.15.md)
++ Gerrit Code Review [v2.15.3](https://www.gerritcodereview.com/2.15.html#2153)
 + GitHub Enterprise [v2.14.2](https://enterprise.github.com/releases/2.14.2),
 [v2.13.8](https://enterprise.github.com/releases/2.13.8),
 [v2.12.16](https://enterprise.github.com/releases/2.12.16),


### PR DESCRIPTION
The Gerrit Code Review project recently migrated its homepage from being hosted on googlesource.com and rendered by Gitiles, to being hosted on Firebase and rendered by Jekyll.

As a result of this migration, the homepage is still under the same domain, but the URLs for the release notes have changed. Instead of  being located at`/releases/$version.md` they are now located at `/$version.html`.

This PR changes the URLs accordingly, and also adds missing anchors for some of the maintenance releases, so that clicking on the link now takes the reader directly to the relevant section for that release.