### PR TITLE
Rev News: add a link to the Git Advent Calendar

### DIFF
--- a/rev_news/drafts/edition-46.md
+++ b/rev_news/drafts/edition-46.md
@@ -43,6 +43,7 @@ __Various__
 
 __Light reading__
 
+* Ed Thomson's [Git Advent Calendar](https://www.edwardthomson.com/blog/git_tips_and_tricks_advent_calendar.html).
 
 __Git tools and sites__
 * [sr.ht](https://sr.ht/) ([https://sr.ht](https://sr.ht/))


### PR DESCRIPTION
It's fun.