### PR TITLE
remove stash'ing merge conflicts project

### DIFF
--- a/SoC-2019-Ideas.md
+++ b/SoC-2019-Ideas.md
@@ -155,23 +155,6 @@ See discussions in:
 <https://public-inbox.org/git/xmqqeg42fslw.fsf@gitster.mtv.corp.google.com/T/#t>
 <http://public-inbox.org/git/CA+55aFwT2HUBzZO8Gpt9tHoJtdRxv9oe3TDoSH5jcEOixRNBXg@mail.gmail.com/>
 
-### Add support for `stash`ing merge conflicts
-
- - Language: C, shell (bash)
- - Difficulty: medium
- - Possible mentors: Christian Couder, Thomas Gummerer
-
-`git stash` currently aborts when the current index state contains
-conflicts.  The idea here is to allow `stash`ing this conflicted
-state, and add an option to `git stash pop` to re-create the conflict.
-This will include writing the technical documentation of the stash
-format, and optionally refactoring the `git stash` code to use more of
-the libgit.a API, instead of the run_command API.
-
-See discussion in:
-
-<https://public-inbox.org/git/20190205211736.GD6085@hank.intra.tgummerer.com>
-
 ### Convert scripts to builtins
 
  - Language: C, shell (bash), possibly Perl


### PR DESCRIPTION
This project depends on stash-in-c going to at least `next`.  I'm
going to send an updated version of the patch series tonight, but
I'm not very confident at this point that it's actually going to
make it to next before GSoC starts.  I'd rather take the project
away now, before applications actually open, and later
re-introduce it, than misleading a student.

---

I wish I didn't have to make this last minute change, however I think it's best not to propose a project that we're not sure at this point is available during summer.  I'd be more than happy to put it back onto the list once stash-in-c made it to `next`.

cc: @chriscool @telezhnaya 