### PR TITLE
SoC-2019-Ideas: don't split text within the `s

### DIFF
--- a/SoC-2019-Ideas.md
+++ b/SoC-2019-Ideas.md
@@ -214,9 +214,9 @@ This would consist in taking care of the following issues:
 * Bonus: Make a flag to allow rebase to rewrite commit messages that
   refer to older commits that were also rebased.  (i.e. if rebasing
   commits A and B, and commit B says `This reverts commit <sha-of-A>`,
-  then rewritten B's commit message should say `This reverts commit
-  <sha-of-rewritten-A>`.)  Do this for both sha1sums and sha1sum
-  abbreviations in commit messages.
+  then rewritten B's commit message should say
+  `This reverts commit <sha-of-rewritten-A>`.)
+  Do this for both sha1sums and sha1sum abbreviations in commit messages.
 
 ## Note about refactoring projects versus projects that implement new features
 


### PR DESCRIPTION
When the text within the ` (tildes)  is split between two lines
it is not rendered as expected. To be precise the part that
comes in the second line isn't visible.

It's worth noting that this is not clear from the rendering
of the markdown by GitHub. But it's clear from the syntax
highlighting done by the editor in GitHub and the rendering
in the website (where this was first noted).