### PR TITLE
RevNews: add an important heads-up for SSH users

### DIFF
--- a/rev_news/drafts/edition-60.md
+++ b/rev_news/drafts/edition-60.md
@@ -218,6 +218,7 @@ You can find more about conversions with reposurgeon
 
 __Various__
 
+* Heads-up for SSH users: as mentioned in [the release notes of OpenSSH v8.2](https://www.openssh.com/txt/release-8.2), the prevalent `ssh-rsa` keys will be disabled. If you use SSH with private keys, you will want to regenerate them soon.
 
 __Light reading__
 


### PR DESCRIPTION
Technically, it is not a piece of _Git_ news per se, but IMO it is rather important for many Git users to be made aware of the deprecation (and soon, disabling) of the `ssh-rsa` keys.