### PR TITLE
Hacking-Git: use a known version for link

### DIFF
--- a/Hacking-Git.md
+++ b/Hacking-Git.md
@@ -26,7 +26,7 @@ people to interesting material that has already been written.
 
 * [Git for Windows' Debugging Git](https://github.com/git-for-windows/git/wiki/Debugging-Git)
 
-* [Launching gdb explanations in CodingGuidelines](https://github.com/git/git/blob/master/Documentation/CodingGuidelines#L441-L445)
+* [Launching gdb explanations in CodingGuidelines](https://github.com/git/git/blob/v2.27.0/Documentation/CodingGuidelines#L441-L445)
 
 * [Explanations by Philippe Blain](https://github.com/gitgitgadget/git/pull/582#issuecomment-599845508)
 


### PR DESCRIPTION
In c271b5d (Hacking-Git: highlight correct lines in CodingGuidelines,
2020-06-07), we fixed lines which are highlighted in the link to the
"Launching gdb explanations in CodingGuidelines" section. However, this
is liable to break in the future as the document is updated.

Hardcode that link to point to the v2.27.0 release of Git instead of the
latest 'master' so that the selected lines will never change.

Although this may potentially present stale information to readers, this
is mitigated by two things. First, I don't anticipate that the GDB
instructions are likely to change. Second, in the section above, there
is a link to the 'master' version of CodingGuidelines so users looking
for that will find a link to the "fresh" version.