### PR TITLE
rn-65: add The history of `master` in git article

### DIFF
--- a/rev_news/drafts/edition-65.md
+++ b/rev_news/drafts/edition-65.md
@@ -17,11 +17,94 @@ This edition covers what happened during the month of June 2020.
 
 ## Discussions
 
-<!---
 ### General
--->
 
-
+* The history of `master` in git
+  
+  Admidst [all the discussion](https://lore.kernel.org/git/CAOAHyQwyXC1Z3v7BZAC+Bq6JBaM7FvBenA-1fcqeDV==apdWDg@mail.gmail.com/)
+  around changing the default branch from `master` to something else,
+  many people have asked why `master` was chosen in the first place.
+  As master has a few different meanings in English, just which
+  meaning was intended?
+  
+  [Konstantin Ryabitsev](https://lore.kernel.org/git/20200504174548.r3zaftqcq52yhd2u@chatter.i7.local/)
+  was the first to discuss the meaning of `master`, saying
+  > Git doesn't use "master-slave" terminology -- the "master" comes
+  from the concept of having a "master" from which copies (branches) are made
+  
+  [This post from the GNOME mailing list](https://mail.gnome.org/archives/desktop-devel-list/2019-May/msg00066.html)
+  was then [linked by Simon Pieters](https://lore.kernel.org/git/CAOAHyQx=+fM1FpAv+g3M+j7j4MgLJA03=MGFmXLvZcfJKAEpGg@mail.gmail.com/)
+  with the claim that
+  > git's `master` is in fact a reference to master/slave
+  
+  That post points out that the first use of `master` was in
+  [a CVS helper script](https://github.com/git/git/commit/3e91311ae750af9bf2e3517b1e701288ac3066b9),
+  links that to BitKeeper (the version control system used to manage
+  Linux development when Linus Torvalds first wrote git), and claims
+  BitKeeper used the "master and slave" meaning of master.
+  
+  Many people considered `master` to mean a "master copy", so this
+  connection to slavery was very surprising.
+  
+  [Andrew Ardill investigated the BitKeeper source code](https://lore.kernel.org/git/a34e4244-835e-976a-8fb4-7fc766d100bd@gmail.com/T/#m9589009ba3b6663ca38c2ef19c18c933e46c253a)
+  and came to the conclusion that "the overwhelming majority of
+  \[the usages of master in BitKeeper\] are of the "Master Copy"
+  variant", or as [Michal Suchánek said](https://lore.kernel.org/git/20200616085004.GB21462@kitsune.suse.cz/)
+  "even in BitKeeper the use of master/slave is the exception rather
+  than the norm."
+  
+  Off the list discussions were ongoing, and
+  [Petr Baudis wrote on twitter about naming the `master` branch in git](https://twitter.com/xpasky/status/1271477451756056577)
+  > I picked the names "master" (and "origin") in the early Git tooling back in 2005.
+  >
+  > (this probably means you shouldn't give much weight to my name preferences :) )
+  >
+  > I have wished many times I would have named them "main" (and "upstream") instead.
+  >
+  > Glad it's happenning @natfriedman
+  
+  Asked which meaning of master was intended,
+  [Petr replied](https://twitter.com/xpasky/status/1272280760280637441)
+  > "master" as in e.g. "master recording". Perhaps you could say the
+  original, but viewed from the production process perspective.
+  >
+  > A clueless Central European youngster whose command of English
+  was mostly illusory came up with the term, which is why it isn't
+  very obvious...
+  
+  In [a follow-up to that original GNOME mailing list post](https://mail.gnome.org/archives/desktop-devel-list/2020-June/msg00023.html),
+  Bastien Nocera retracted their claims from the original post, saying
+  > I emailed Linus Torvalds recently... and he told me that it was
+  unlikely that the "git master" branch name was influenced by
+  BitKeeper, and that "master" was "fairly standard naming" for this
+  sort of thing and "more likely to be influenced by the
+  CVS master repository"
+  
+  Going on, Bastien discusses Petr Baudis' tweets and then concludes
+  "it doesn't matter where the name comes from... The fact that it has
+  bad connotations, or inspires dread for individuals and whole
+  communities, is reason enough to change it."
+  
+  This is something that
+  [Brian M. Carlson had also pointed out on the git mailing list](https://lore.kernel.org/git/20200505231641.GH6530@camp.crustytoothpaste.net/),
+  saying
+  > "master", even though from a different origin, brings the idea of
+  human bondage and suffering to mind for a non-trivial number of
+  people, which of course was not the intention and is undesirable.
+  I suspect if we were making the decision today, we'd pick another
+  name, since that's not what we want people to think of when they use Git.
+  
+  Brian goes on to lay out changes required in git to rename `master`
+  as the default, suggesting that there is a decent amount of work and
+  that due to compatibility concerns "we'd probably want to make it in
+  a \[git version\] 3.0".
+  
+  Around the web the discussion about renaming `master` continues.
+  The incorrect claims around the history of `master` persist, even in
+  our own [Git Rev News: Edition 64](https://git.github.io/rev_news/2020/06/25/edition-64/#other-news),
+  but seem to be quickly corrected where possible such as on
+  [git-lab's discussion on the topic](https://gitlab.com/gitlab-org/gitlab/-/issues/221164#note_372560473).
+  
 ### Reviews
 
 * [More commit-graph/Bloom filter improvements](https://lore.kernel.org/git/pull.659.git.1592252093.gitgitgadget@gmail.com/)


### PR DESCRIPTION
Here is my initial attempt at an article. Please let me know your thoughts and what can be improved.

The 'General' section seemed most appropriate as I referenced quite a few different posts to the mailing list thread to show how the discussion evolved.

I wasn't sure about quoting style that should be used, and I ended up using quote formatting for the main arguments to try and highlight them, in-lining other quotes where it seemed appropriate.

I wasn't entirely sure how to resolve the article, so any feedback on that would be great as well.