### PR TITLE
Add a footer with a link to the site repo on GitHub

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,2 @@
+<hr/>
+<p>Contribute to this site by <a href="https://github.com/git/git.github.io/fork">forking it on GitHub!<a/></p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,7 @@
               {{ content }}
 
               <div class="footer">
-                <!-- nothing yet -->
+                {% include footer.html %}
               </div>
             </div>
 


### PR DESCRIPTION
Let's make it easy for potential contributors to know how to contribute
to this website by adding a footer and linking to the site repo.

Include '/fork' in the URL so it's even easier.

Closes git/git.github.io#434