### PR TITLE
rn-69: fix link to 'Git before Github' article

### DIFF
--- a/rev_news/drafts/edition-69.md
+++ b/rev_news/drafts/edition-69.md
@@ -43,7 +43,7 @@ __Various__
 
 __Light reading__
 
-* [Git before GitHub](https://github.com/tarunbatra/git-before-github/)
+* [Git before GitHub](https://tarunbatra.com/blog/x/git-before-github/)
 by Tarun Batra is a beginner-friendly article explaining how to submit
 patches using git's built-in tools without using a platform like GitHub.
 


### PR DESCRIPTION
Fixes issue in the link caught by @sivaraam [here](https://github.com/git/git.github.io/pull/465#issuecomment-728202495).