### PR TITLE
CSS font fixes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -23,7 +23,7 @@ body {
   line-height: 1;
   font-size: 14px;
   line-height: 22px;
-  font-family: Adelle, Georgia, Times New Roman, serif;
+  font-family: Adelle, Roboto Slab, DejaVu Serif, Georgia, Times New Roman, sans-serif;
   color: #4e443c;
   background: #f0efe7;
 }
@@ -998,7 +998,7 @@ input.active {
 
 
 input, textarea {
-  font-family: Adelle, Georgia, Times New Roman, serif;
+  font-family: Adelle, Roboto Slab, DejaVu Serif, Georgia, Times New Roman, sans-serif;
   font-size: 14px;
   outline: none;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -23,7 +23,7 @@ body {
   line-height: 1;
   font-size: 14px;
   line-height: 22px;
-  font-family: "adelle", Georgia, "Times New Roman", serif;
+  font-family: Adelle, Georgia, Times New Roman, serif;
   color: #4e443c;
   background: #f0efe7;
 }
@@ -998,7 +998,7 @@ input.active {
 
 
 input, textarea {
-  font-family: "adelle", Georgia, "Times New Roman", serif;
+  font-family: Adelle, Georgia, Times New Roman, serif;
   font-size: 14px;
   outline: none;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -123,15 +123,6 @@ article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, 
   display: block;
 }
 
-body {
-  font-size: 14px;
-  line-height: 22px;
-  font-family: "adelle", Georgia, "Times New Roman", serif;
-  color: #4e443c;
-  margin: 0;
-  padding: 0;
-}
-
 .inner {
   overflow: hidden;
   *zoom: 1;

--- a/css/main.css
+++ b/css/main.css
@@ -132,11 +132,6 @@ body {
   padding: 0;
 }
 
-.windows.chrome body,
-.windows.ie8 body {
-  font-family: Georgia, "Times New Roman", serif !important;
-}
-
 .inner {
   overflow: hidden;
   *zoom: 1;
@@ -1019,12 +1014,6 @@ input, textarea {
 }
 
 
-.windows.chrome input, .windows.chrome textarea,
-.windows.ie8 input, .windows.chrome textarea {
-  font-family: Georgia, "Times New Roman", serif !important;
-}
-
-
 form#search {
   position: absolute;
   z-index: 1000;
@@ -1528,11 +1517,6 @@ pre.sh_sourceCode .sh_value {
   color: #008800;
   font-weight: normal;
   font-style: normal;
-}
-
-.windows.chrome body *,
-.windows.ie8 body * {
-  font-family: Georgia, "Times New Roman", serif !important;
 }
 
 header {

--- a/css/main.css
+++ b/css/main.css
@@ -20,7 +20,6 @@ time, mark, audio, video {
 }
 
 body {
-  font-family: sans-serif;
   line-height: 1;
   font-size: 14px;
   line-height: 22px;


### PR DESCRIPTION
A few cleanups, plus fixes for Linux systems, which don't have any of the fonts listed.

This basically adds Roboto Slab, and DejaVu Serif to the list of font-family, which makes it readable in Linux systems. Plus the fallback to sans-serif (we are not in 90s anymore).

I tested this in Arch Linux, Android 9, and Windows 10. Everything looks the same, except Arch Linux.

This fixes issue #469.