### PR TITLE
css: improvements to "move the left margin"

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -36,6 +36,7 @@ body {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
+    max-width: 660px;
 }
 
 .navbar {
@@ -62,7 +63,7 @@ body {
   display: -ms-flexbox;
   display: flex;
   margin: 0 auto;
-  max-width: 940px;
+  justify-content: center;
 }
 
 @media (max-width: 700px) {

--- a/css/main.css
+++ b/css/main.css
@@ -44,6 +44,7 @@ body {
   text-align: left;
   width: 15em;
   padding: 2em;
+  padding-right: 0;
 }
 
 #menuLinkBar {

--- a/css/main.css
+++ b/css/main.css
@@ -36,13 +36,13 @@ body {
     -webkit-flex: 1;
     -ms-flex: 1;
     flex: 1;
-    max-width: 660px;
+    max-width: 700px;
 }
 
 .navbar {
   float: left;
   text-align: left;
-  width: 20em;
+  width: 15em;
   padding: 2em;
 }
 


### PR DESCRIPTION
As @jnareb mentioned in issue #463, it should be possible to "move the left margin" so the navbar isn't squeezed.

However, conceptually what is actually being done is very different: the container wrapper is expanded to the full width of the window, then, the elements inside are justified to the center, this way the browser knows where to place the "left margin" (the left-most location where the navbar starts), but in order for the elements to not expand to the full width of the window, a max-width for the site container is necessary.

While on it, I adjusted the sizes of the navbar and the site containers, and removed some extra unnecessary padding.