### PR TITLE
Added Git metadata cloning article link

### DIFF
--- a/rev_news/drafts/edition-71.md
+++ b/rev_news/drafts/edition-71.md
@@ -43,6 +43,8 @@ __Various__
 
 __Light reading__
 
+* [Git Metadata Cloning](https://www.alchemists.io/articles/git_metadata_cloning)- Learn about the
+  performance impacts of cloning repository metadata.
 
 __Git tools and sites__
 


### PR DESCRIPTION
## Overview

Provides additional insight into different kinds of cloning, especially
when you only care about repository metadata.

## Details

- Resolves comment in [Issue 475](https://github.com/git/git.github.io/issues/475).
