### PR TITLE
SoC-2021-Ideas: wrap <format> with backquote

### DIFF
--- a/SoC-2021-Ideas.md
+++ b/SoC-2021-Ideas.md
@@ -24,8 +24,8 @@ page though.
  - Possible mentors: Hariom Verma, Christian Couder
 
 `git cat-file` has options `--batch[=<format>]` and
-`--batch-check[=<format>]` that can take a <format>. It would be nice
-if the implementation of this <format> would use the as much as
+`--batch-check[=<format>]` that can take a `<format>`. It would be nice
+if the implementation of this `<format>` would use the as much as
 possible the same code and syntax as the ref-filter formats.
 
 Git used to have an old problem of duplicated implementations of some


### PR DESCRIPTION
The "\<format\>" in the project "Use ref-filter formats in `git cat-file`" is not visible [here](https://git.github.io/SoC-2021-Ideas/). 

This PR is to fix that issue.  