### PR TITLE
Update IRC link to Libera Chat

### DIFF
--- a/Hacking-Git.md
+++ b/Hacking-Git.md
@@ -90,7 +90,7 @@ suggest improvements. Thanks!
 
 * [git-scm community page](https://git-scm.com/community)
 
-* [freenode webchat for the #git-devel IRC channel](https://webchat.freenode.net/#git-devel)
+* [web interface to #git-devel IRC channel on Libera Chat](https://web.libera.chat/#git-devel)
 
 * [#git-devel IRC channel archive](https://colabti.org/irclogger/irclogger_logs/git-devel)
 


### PR DESCRIPTION
Libera Chat seems to be the go-to place for a lot of Git developers, and the last standup meeting happened there. Safe to say, new contributors are more likely to get their questions answered there.

Since there seems to be no way to directly link Libera's web chat to `#git-devel` directly, I have put a generic link over the text 'Libera Chat'. Users will have to manually type `#git-devel` in the webchat interface, but I suppose that should be obvious enough to not be worth mentioning.