### PR TITLE
index: make this website definitive

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,19 +6,23 @@ navbar: false
 
 # {{ page.title }}
 
-This is a tentative homepage for information on Git development. If you
+This is a website for information on Git development. If you
 stumbled into this by mistake, you may want:
 
   - <http://git-scm.com>, which has information on running
-    git and links to download the latest version
+    Git and links to download the latest version
 
   - <http://git.wiki.kernel.org>, the wiki that has historically
     contained developer information
 
 These pages are intended to collect information useful to Git
-developers, including collaborative editing of documents (i.e., it is an
-alternative to us having a wiki, but one that is edited entirely via git
-pushes).
+developers. This is also the web home of:
 
-Note that this page is an experiment and a work in progress. It may go
-away at any time if it turns out not to be useful.
+  - the [Git Rev News newsletter](/rev_news/),
+  - the [involvement of the Git project in mentoring programs](/General-Application-Information/)
+    like [Outreachy](https://www.outreachy.org/) and the
+    [GSoC (Google Summer of Code)](https://summerofcode.withgoogle.com/)
+
+These pages are intended to be edited collaboratively (i.e., it is an
+alternative to us having a wiki, but one that is edited entirely via Git
+pushes).


### PR DESCRIPTION
Let's acknowledge that this website isn't an experiment anymore and that it contains information about Git Rev News and the Git project involvement in the GSoC and Outreachy mentoring programs.
