### PR TITLE
rn-80: mention "git autofixup"

### DIFF
--- a/rev_news/drafts/edition-80.md
+++ b/rev_news/drafts/edition-80.md
@@ -46,6 +46,8 @@ __Light reading__
 
 __Git tools and sites__
 
+* [git-autofixup](https://github.com/torbiak/git-autofixup) automatically
+  creates fixup commits for topic branches.
 
 ## Credits
 


### PR DESCRIPTION
This is not exactly new, but I think it's really useful, and it has only
been mentioned on the Git list once.
That page also references two blog posts; one that goes as far as explaining
the heuristic used to assign fixup commits, and another one that introduces the
use case to beginners, see https://github.com/torbiak/git-autofixup#articles