### PR TITLE
rn-80: Git Cola v3.11.0 was released

### DIFF
--- a/rev_news/drafts/edition-80.md
+++ b/rev_news/drafts/edition-80.md
@@ -286,6 +286,7 @@ This edition covers what happened during the month of September 2021.
 + GitKraken [8.1.0](https://support.gitkraken.com/release-notes/current),
 [8.0.1](https://support.gitkraken.com/release-notes/current)
 + GitHub Desktop [2.9.4](https://desktop.github.com/release-notes/)
++ Git Cola [3.11.0](http://git-cola.github.io/share/doc/git-cola/html/relnotes.html#v3-11-0)
 
 ## Other News
 


### PR DESCRIPTION
Link to the recent Git Cola v3.11.0 release in Edition 80 of Git Rev News.