### PR TITLE
Add GSoC 2022 material and hide 2021 material

### DIFF
--- a/SoC-2021-Ideas.md
+++ b/SoC-2021-Ideas.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: SoC 2021 Ideas
+navbar: false
 ---
 
 This is the idea page for Summer of Code 2021 for Git.

--- a/SoC-2022-Ideas.md
+++ b/SoC-2022-Ideas.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: SoC 2022 Ideas
+---
+
+This is the idea page for Summer of Code 2022 for Git.
+
+*Please completely read the [general application information](https://git.github.io/General-Application-Information)
+page before reading the idea list below.*
+
+## Summer of code main project ideas
+
+**Students**: Please consider these ideas as starting points for
+generating proposals. We are also more than happy to receive proposals
+for other ideas related to Git. Make sure you have read the "Note
+about refactoring projects versus projects that implement new
+features" in the [general application information](https://git.github.io/General-Application-Information)
+page though.
+
+### Idea X
+_TBD: Ideas to be added based on discussion with community_

--- a/SoC-2022-Microprojects.md
+++ b/SoC-2022-Microprojects.md
@@ -1,7 +1,6 @@
 ---
 layout: default
-title: Outreachy Winter 2021-2022 Applicant Microprojects
-navbar: false
+title: SoC 2022 Applicant Microprojects
 ---
 
 ## Introduction


### PR DESCRIPTION
The ideas document is mostly empty now. Ideas are yet to be gathered
from the community and added.

We also hide the SoC 2021 documents and Outreachy microproject documents
as they're stale now. The SoC 2021 org application isn't hidden as
we haven't applied for 2022 yet.

**Note**: I'm creating the ideas doc without any ideas to make it easy for others to open a PR, if necessary.