### PR TITLE
archive.md: Update `About Rev News` link

### DIFF
--- a/rev_news/archive.md
+++ b/rev_news/archive.md
@@ -5,7 +5,7 @@ title: Git Rev News Archive
 
 # Archive
 
-Here you can see all the previous editions. See [About Git Rev News](/rev_news/rev_news/) for ways you can subscribe.
+Here you can see all the previous editions. See [About Git Rev News](https://git.github.io/about/) for ways you can subscribe.
 
 <ul>
   {% for post in site.posts %}


### PR DESCRIPTION
The current `About Rev News` link results in a 404.
Link direct to the git.github.io page.

Fixes one point in #545 

Signed-off-by: Philip Oakley philipoakley@iee.email