### PR TITLE
add 'Rev News' note to the top level README page

### DIFF
--- a/_includes/README.md
+++ b/_includes/README.md
@@ -16,6 +16,9 @@ It is meant to be edited collaboratively like a wiki, except that
 instead of a web form, you get to use a text editor and Git. What could
 be better?
 
+These pages also host the [Git Rev News](https://git.github.io/rev_news/),
+see the [About Git Rev News](https://git.github.io/rev_news/rev_news/) page.
+
 If you want push access, contact peff@peff.net and provide your GitHub
 username. You may also send patches by mail (and feel free to cc
 git@vger.kernel.org if appropriate).


### PR DESCRIPTION
The git.github.io pages set out to be a website to help Git Developers.

Highlight the linkage to the Git Rev News pages to help new contributors
find the Rev News contributions particularly when the repo layout is
subtly different from  web pages.

Signed-off-by: Philip Oakley <philipoakley@iee.email>