### PR TITLE
_includes/README.md: update current set of admins

### DIFF
--- a/_includes/README.md
+++ b/_includes/README.md
@@ -19,9 +19,10 @@ be better?
 These pages also host the [Git Rev News](https://git.github.io/rev_news/),
 see the [About Git Rev News](https://git.github.io/rev_news/rev_news/) page.
 
-If you want push access, contact peff@peff.net and provide your GitHub
-username. You may also send patches by mail (and feel free to cc
-git@vger.kernel.org if appropriate).
+If you want push access, contact Christian Couder
+\<<christian.couder@gmail.com>\> or Taylor Blau \<<me@ttaylorr.com>\> and
+provide your GitHub username. You may also send patches by mail (and
+feel free to cc git@vger.kernel.org if appropriate).
 
 
 # Development


### PR DESCRIPTION
While Peff is taking a break from Git, update the list of people with
admin-rights on git/git.github.io to reflect who is active and can grant
push access to interested contributors.

Closes: git/git.github.io#553

##

/cc @chriscool, @sivaraam 