### PR TITLE
Add article to Light Reading section

### DIFF
--- a/rev_news/drafts/edition-85.md
+++ b/rev_news/drafts/edition-85.md
@@ -42,7 +42,7 @@ __Various__
 
 
 __Light reading__
-
+- [How to Really Use Git: 10 Rules to Make Git More Useful](https://hackernoon.com/how-to-really-use-git-10-rules-to-make-git-more-useful) by Bruno Brito on HackerNoon.
 
 __Git tools and sites__
 


### PR DESCRIPTION
I published [this article](https://hackernoon.com/how-to-really-use-git-10-rules-to-make-git-more-useful) on HackerNoon this week. I think it fits nicely in the "Light Reading" section 🙂