### PR TITLE
SoC-2022-Ideas: linkify email links

### DIFF
--- a/SoC-2022-Ideas.md
+++ b/SoC-2022-Ideas.md
@@ -72,8 +72,8 @@ Difficulty: Medium
 Languages: C, shell(bash)
 
 Possible mentors:
-* Derrick Stolee `<derrickstolee@github.com>`
-* Victoria Dye `<vdye@github.com>`
+* Derrick Stolee < <derrickstolee@github.com> >
+* Victoria Dye < <vdye@github.com> >
 
 ### Unify ref-filter formats with other pretty formats
 
@@ -100,8 +100,8 @@ Difficulty: Medium
 Languages: C, shell(bash)
 
 Possible mentors:
-* Christian Couder `<christian.couder@gmail.com>`
-* Hariom Verma `<hariom18599@gmail.com>`
+* Christian Couder < <christian.couder@gmail.com> >
+* Hariom Verma < <hariom18599@gmail.com> >
 
 ### Reachability bitmap improvements
 
@@ -180,8 +180,8 @@ Difficulty: Medium
 Languages: C, shell
 
 Possible mentors:
-* Taylor Blau `<me@ttaylorr.com>`
-* Kaartic Sivaraam `<kaartic.sivaraam@gmail.com>`
+* Taylor Blau < <me@ttaylorr.com> >
+* Kaartic Sivaraam < <kaartic.sivaraam@gmail.com> >
 
 [vmg-bitmaps]: https://github.blog/2015-09-22-counting-objects/
 [ewah]: https://arxiv.org/abs/0901.3751


### PR DESCRIPTION
E-mails were wrapped in backticks which resulted in them rendering
as code snippets.

Tweak the e-mails so that they are rendered in a linkified manner.
This would help students to easily copy e-mails address (or) send
e-mails to potential mentors.

### Note
I'm creating this one as a PR as I'm kind of unsure of the reason the e-mails have been wrapped in codeblocks rather than being linkified. Does wrapping the e-mails in code block offer some kind of spam protection?