### PR TITLE
General-Microproject-Information: convert travis-ci to github actions

### DIFF
--- a/General-Microproject-Information.md
+++ b/General-Microproject-Information.md
@@ -100,15 +100,27 @@ the following steps:
   signify your agreement by adding a `Signed-off-by` line.
 
 * *Optional, but recommended:*
-  Create a fork of [Git](https://github.com/git/git) on github.com,
-  [sign in to Travis CI](https://travis-ci.org/auth) with your GitHub
-  account, accepting the GitHub
-  [access permissions confirmation](https://docs.travis-ci.com/user/github-oauth-scopes),
-  and enable builds of your Git fork in your Travis CI profile
-  (you only have to do these steps once). Afterwards you can push
-  your changes to your fork and on <https://travis-ci.org/your-github-name/git/builds>
-  (example [here](https://travis-ci.org/git/git/builds)) you can see
-  if your changes pass the Git test suite on Ubuntu Linux and on Mac OS X.
+  With an account at GitHub, you can use GitHub CI to test your changes
+  on Linux, Mac and Windows. See
+  [examples](https://github.com/git/git/actions/workflows/main.yml)
+  of recent CI runs.
+
+  To run these tests against your own branch,
+  [create a fork](https://help.github.com/articles/fork-a-repo/)
+  of [Git](https://github.com/git/git) on GitHub and switch to it. At the
+  top bar select [Actions tab](https://github.com/git/git/actions)
+  and perform the initial setup to enable it for your fork. After enabling it,
+  CI will run for a specific branch of your fork whenever you push new changes
+  to it in GitHub. You can monitor the test state of all your branches in the
+  same [Actions tab](https://github.com/git/git/actions) of your fork.
+
+  If a branch did not pass all test cases then it is marked with a red cross. In
+  that case you can click on the failing job and navigate to
+  "ci/run-build-and-tests.sh" and/or \
+  "ci/print-test-failures.sh". You can also
+  download "Artifacts" which are tarred (or zipped) archives with test data
+  relevant for debugging. Fix the problem and push your fix to your GitHub fork.
+  This will trigger a new CI build. Ensure all tests pass.
 
 * Submit your change to the Git mailing list. For this step you
   probably want to use the commands `git format-patch` and `git


### PR DESCRIPTION
Git has converted from using travis-ci to github actions in commit
https://github.com/git/git/commit/4a6e4b9602630d50eb9d630c721bb01df97049f9.
We also need to update the documentation for possible SoC candidates.

The instructions for GitHub actions were strongly influenced by commit
https://github.com/git/git/commit/f003a91f5c5695a44a94efe9171bc905fbfa27ce.

Signed-off-by: Plato Kiorpelidis <kioplato@gmail.com>