### PR TITLE
rn-86: add git worktree article to light reading

### DIFF
--- a/rev_news/drafts/edition-86.md
+++ b/rev_news/drafts/edition-86.md
@@ -237,7 +237,8 @@ __Light reading__
 + [Use Git tactically](https://stackoverflow.blog/2022/04/06/use-git-tactically/):
   How you can use micro-commits to effectively apply the [Strangler Fig pattern](https://martinfowler.com/bliki/StranglerFigApplication.html),
   by Mark Seeman on The Overflow (Stack Overflow blog).
-
++ [Working on two git branches at once with git worktree](https://andrewlock.net/working-on-two-git-branches-at-once-with-git-worktree)
+  by Andrew Lock on andrewlock\.net.
 
 __Git tools and sites__
 


### PR DESCRIPTION
Sorry it's a bit last minute and I totally understand if it's too late for this month, but I just came across this article that shows an interesting use case for `git worktree` that I wasn't familiar with.