### PR TITLE
Re-create icons within your GitHub history graph

### DIFF
--- a/rev_news/drafts/edition-96.md
+++ b/rev_news/drafts/edition-96.md
@@ -139,6 +139,7 @@ __Easy watching__
 
 __Git tools and sites__
 
++ [Gitifi](https://github.com/gelstudios/gitfiti) gitfiti noun : Carefully crafted graffiti in a github commit history calendar.
 
 ## Credits
 


### PR DESCRIPTION
Decorate your github account's commit history calendar by (blatantly) abusing git's ability to accept commits in the past. A light hearted piece of art (might belong in another section).