### PR TITLE
SoC 2023: update sparse index command list

### DIFF
--- a/SoC-2023-Ideas.md
+++ b/SoC-2023-Ideas.md
@@ -47,18 +47,17 @@ This allows the student to gain partial success early in the project and
 the student can complete as many as possible in the timeframe (without
 expectation that _all_ will be completed during the project).
 
-* `git rev-parse`
-* `git fsck`
-* `git check-attr`
 * `git describe`
+* `git write-tree`
 * `git diff-files`
 * `git diff-index`
 * `git diff-tree`
 * `git worktree`
-* `git write-tree`
+* `git check-attr`
+* `git checkout--worker` (for parallel checkout)
 * `git apply`
 * `git am`
-* `git checkout--worker` (for parallel checkout)
+* `git fsck`
 * `git merge-index`
 * `git rerere`
 


### PR DESCRIPTION
Remove 'rev-parse', since it was already integrated with sparse index last year [1]. Additionally, reorder the list of commands to reflect the relative difficulty of sparse index integrations, taking into account both the additional work of adding sparse-checkout compatibility (if needed) and what has been made easier as a result of other commands' integrations.

[1] https://lore.kernel.org/git/69efe637a18786b289db79971e9e49137306b57c.1651005800.git.gitgitgadget@gmail.com