### PR TITLE
Add Shuqi blog details & fix typo

### DIFF
--- a/rev_news/drafts/edition-100.md
+++ b/rev_news/drafts/edition-100.md
@@ -30,7 +30,8 @@ This edition covers what happened during the months of May 2023 and June 2023.
       Some details about his work on the project could found in [his blog](https://five-sh.github.io/blog).
 
     - Shuqi Liang will work on the "[More Sparse Index Integrations](https://summerofcode.withgoogle.com/programs/2023/projects/Rkbc1Abe)"
-      project. Shuqi will be mentored by Victoria Dye.
+      project. Shuqi will be mentored by Victoria Dye. Further details about
+      the project and updates on progress can be found on [Shuqi's blog](https://cheskaqiqi.github.io/tags/GSoC/).
 
   Congratulations to the selected contributors!
 

--- a/rev_news/drafts/edition-100.md
+++ b/rev_news/drafts/edition-100.md
@@ -27,7 +27,7 @@ This edition covers what happened during the months of May 2023 and June 2023.
 
     - Kousik Sanagavarapu will work on the "[Unify ref-filter formats with other pretty formats](https://summerofcode.withgoogle.com/programs/2023/projects/rck3kmq2)"
       project. Kousik will be co-mentored by Hariom Verma and Christian Couder.
-      Some details about his work on the project could found in [his blog](https://five-sh.github.io/blog).
+      Some details about his work on the project could be found in [his blog](https://five-sh.github.io/blog).
 
     - Shuqi Liang will work on the "[More Sparse Index Integrations](https://summerofcode.withgoogle.com/programs/2023/projects/Rkbc1Abe)"
       project. Shuqi will be mentored by Victoria Dye. Further details about


### PR DESCRIPTION
Re: https://github.com/git/git.github.io/pull/648#issue-1761972141, added blog details as shared by @cheskaqiqi [on the mailing list](https://lore.kernel.org/git/20230619145342.5830-1-cheskaqiqi@gmail.com/). Also, fixed a typo (s/could/could be) in the entry on Kousik's blog.