### PR TITLE
rn-103: Link to .gitkeep post

### DIFF
--- a/rev_news/drafts/edition-103.md
+++ b/rev_news/drafts/edition-103.md
@@ -40,6 +40,8 @@ __Various__
 
 __Light reading__
 
+* [Don’t create `.gitkeep` files, use `.gitignore` instead](https://adamj.eu/tech/2023/09/18/git-dont-create-gitkeep/) by Adam Johnson.
+
 <!---
 __Easy watching__
 -->


### PR DESCRIPTION
Ref #660 for the upcoming edition.

If there’s an RSS reader that links are pulled from, my Git-related posts can be subscribed to at https://adamj.eu/tech/atom-git.xml .

I’ll be releasing my book “Boost Your Git DX” soon, probably before Rev News 104, so it would be nice to add it then.

Thanks 🙏