### PR TITLE
fixed width that's lesser than the content width #472

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -47,6 +47,8 @@ body {
   padding-right: 0;
 }
 
+
+
 #menuLinkBar {
     background-color: #a09a93;
     text-align: right;
@@ -92,6 +94,24 @@ body {
     #menuLinkBar {
         display: block;
     }
+}
+
+@media (max-width: 750px) {
+
+  h2 {
+      font-size: 2.5em !important;
+      letter-spacing: 0.1em; 
+      line-height: 3; 
+  }
+  p {
+      font-size: 2.2em !important;
+      /* letter-spacing: 0.1em;  */
+      line-height: 2; 
+  }
+  .site {
+      font-size: 1em;
+      line-height: 2; 
+  } 
 }
 
 ol, ul {
@@ -517,7 +537,7 @@ table.benchmarks tr td {
 p {
   margin: 0 0 11px;
   font-size: 14px;
-  line-height: 22px;
+  /* line-height: 22px; */
 }
 
 p small {

--- a/css/main.css
+++ b/css/main.css
@@ -65,9 +65,10 @@ body {
   display: flex;
   margin: 0 auto;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
-@media (max-width: 700px) {
+@media (max-width: 993px) {
     #wrapper {
         -webkit-box-orient: vertical;
         -webkit-box-direction: normal;


### PR DESCRIPTION
The website's responsiveness was enhanced with "flex-wrap: wrap," and the layout adjustment at "@media (max-width: 993px)" ensures optimal display on various devices, creating a fully functional and user-friendly experience. [Ensure code-blocks take-up fixed width that's lesser than the content width #472](https://github.com/git/git.github.io/issues/472)
