### PR TITLE
SoC-2024: include the organization logo at a prominent place

### DIFF
--- a/SoC-2024-Ideas.md
+++ b/SoC-2024-Ideas.md
@@ -3,6 +3,8 @@ layout: default
 title: SoC 2024 Ideas
 ---
 
+<img style="float: right;" src="https://git-scm.com/images/logos/downloads/Git-Logo-2Color.svg">
+
 This is the idea page for Summer of Code 2024 for Git.
 
 *Please completely read the [general application information](https://git.github.io/General-Application-Information)


### PR DESCRIPTION
This is a suggestion by Google.

The change right now renders as follows locally.

![image](https://github.com/git/git.github.io/assets/12448084/a3864e09-7868-4e12-bf62-76e51db234ac)

## An alternative rendering

<details><summary>If we use simple markdown syntax for including an image, it renders as follows.</summary>
<p>

![image](https://github.com/git/git.github.io/assets/12448084/0ec63b64-02a8-49eb-8945-ef43c5a1a3ca)

</p>
</details> 

I'm fine with either rendering. Feel free to share your thoughts. 🙂 
