### PR TITLE
SoC-2024: improve positioning of logo in small screens

### DIFF
--- a/SoC-2024-Ideas.md
+++ b/SoC-2024-Ideas.md
@@ -3,7 +3,7 @@ layout: default
 title: SoC 2024 Ideas
 ---
 
-<img style="float: right;" src="https://git-scm.com/images/logos/downloads/Git-Logo-2Color.svg">
+![git logo >](https://git-scm.com/images/logos/downloads/Git-Logo-2Color.svg)
 
 This is the idea page for Summer of Code 2024 for Git.
 

--- a/css/main.css
+++ b/css/main.css
@@ -2062,3 +2062,30 @@ img {
   padding-left: 2em;
   text-indent: -2em;
 }
+
+@media screen and (min-width: 800px) {
+  img[alt$=">"] {
+    float: right;
+  }
+
+  /*
+   * Below styles could be useful when we position
+   * images to left / center. They're commented now
+   * since we don't use images in our site much.
+   *
+   * Ref: https://stackoverflow.com/a/39614958/5614968
+   */
+  /*
+  img[alt$="<"] {
+    float: left;
+  }
+
+  img[alt$="><"] {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: auto;
+    float: none!important;
+  }
+  */
+}


### PR DESCRIPTION
We could align the image to right only on bigger screens as it looks good only when the space on the left is enough for some decent amount of content to be shown. On smaller screens, we could just place the image on its one chunk of space (default behaviour when including images in Markdown) and let the content follow it.

Tweak the styles to accordingly for this.

<details><summary>Screen shot of page on big screen</summary>
<p>

![image](https://github.com/git/git.github.io/assets/12448084/726d6ba1-9b5a-4561-a618-95e41317ba23)

</p>
</details> 


<details><summary>Screen shot of page on small screen</summary>
<p>

![image](https://github.com/git/git.github.io/assets/12448084/5b7d5e73-1945-4831-8163-4b2fbf893e4e)

</p>
</details> 