### PR TITLE
GSoC-particpants: add file with  partial info about participants

### DIFF
--- a/GSoC-Participants.md
+++ b/GSoC-Participants.md
@@ -1,0 +1,135 @@
+---
+layout: default
+title: GSoC participants
+---
+
+This document collects the list of contributors who've contributed
+to Git via GSoC.
+
+<!-- [ [project]() ] [ [final report]() ] [ [blog]() ] -->
+
+### 2023
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2023/organizations/git)
+
+### 2022
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2022/organizations/git)
+
+### 2021
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2021/organizations/6398200235163648)
+
+### 2020
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2020/organizations/5445576591671296)
+
+### 2019
+
+1. Rohit Ashiwal [ [project](https://summerofcode.withgoogle.com/archive/2019/projects/5390155215536128) ] [ [final report](https://web.archive.org/web/20210727190950/https://rashiwal.me/2019/final-report/) ] [ [blog](https://web.archive.org/web/20210515085551/https://rashiwal.me/) ]
+2. Matheus Tavares [ [project](https://summerofcode.withgoogle.com/archive/2019/projects/4787791739748352) ] [ [final report](https://matheustavares.gitlab.io/posts/gsoc-final-report) ] [ [blog](https://matheustavares.gitlab.io/tags/git/) ]
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2019/organizations/6548634445807616)
+- [Rev News - May 2019](https://git.github.io/rev_news/2019/05/22/edition-51/)
+
+
+### 2018
+
+1. Pratik Karki [ [project](https://summerofcode.withgoogle.com/archive/2018/projects/5389615745728512) ] [ [final report](https://github.com/prertik/GSoC2018?tab=readme-ov-file) ] [ [blogs](https://prertik.github.io/categories/git/) ]
+2. Paul-Sebastian Ungureanu [ [project](https://summerofcode.withgoogle.com/archive/2018/projects/6700324135895040) ] [ [final report and blogs](https://github.com/ungps/gsoc2018?tab=readme-ov-file) ]
+3. Alban Gruin [ [project](https://summerofcode.withgoogle.com/archive/2018/projects/6165469845258240) ] [ [final report](https://github.com/agrn/gsoc2018?tab=readme-ov-file) ] [ [blogs](https://blog.pa1ch.fr/category/gsoc-2018.html) ]
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2018/organizations/4840889583140864)
+- [Rev News - May 2018](https://git.github.io/rev_news/2018/05/16/edition-39/)
+
+### 2017
+
+1. Prathamesh Chavan [ [project](https://summerofcode.withgoogle.com/archive/2017/projects/5434523185577984) ] [ [final report](https://docs.google.com/document/d/1RmUvJBf4x8TI71Fltg8xWP-s7zkhz3bGPyEJMgRx91Y/edit#heading=h.5r7i4cugqwi3) ]
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2017/organizations/5061577619275776)
+- [Rev News - Oct 2017](https://git.github.io/rev_news/2017/10/11/edition-32/)
+
+### 2016
+
+1. Pranit Bauva [ [project](https://summerofcode.withgoogle.com/archive/2016/projects/5595001820020736) ] [ [final report](https://docs.google.com/document/d/1Uir0a8cRYlWANuzoU4iTDtEvPukvtTJcC_dB3KJUgqM/edit#heading=h.mipx2w79za4f) ]
+
+#### References
+
+- [GSoC archive](https://summerofcode.withgoogle.com/archive/2016/organizations/5532648021688320#projects-list)
+- [Rev News - Oct 2016](https://git.github.io/rev_news/2016/09/14/edition-19/)
+
+### 2015
+
+1. Karthik Nayak [ [project](https://www.google-melange.com/archive/gsoc/2015/orgs/git/projects/karthiknayak94.html) ] [ [fork](https://github.com/KarthikNayak/git) ] [ [a mailing list mail](https://public-inbox.org/git/553F7A50.1080907@gmail.com/) ] 
+2. Paul Tan [ [project](https://www.google-melange.com/archive/gsoc/2015/orgs/git/projects/pyokagan.html) ] [ [fork](https://github.com/pyokagan/git) ] [ [a mailing list mail](https://public-inbox.org/git/CACRoPnQ5_r-26J4gBHc27KZt3X9KAU7eFkA3vz_GE6_dP-Uyug@mail.gmail.com/) ] 
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2015/orgs/git)
+- [Rev News - May 2015](https://git.github.io/rev_news/2015/05/13/edition-3/#other-news)
+
+### 2014
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2014/orgs/git)
+
+### 2013
+
+*Did not participate*
+
+### 2012
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2012/orgs/git)
+
+### 2011
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2011/orgs/git)
+
+### 2010
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2010/orgs/git)
+
+### 2009
+
+*TODO*
+
+#### References
+
+- [GSoC archive](https://www.google-melange.com/archive/gsoc/2009/orgs/git)

--- a/GSoC-Participants.md
+++ b/GSoC-Participants.md
@@ -10,35 +10,48 @@ to Git via GSoC.
 
 ### 2023
 
-*TODO*
+1. Shuqi Liang [ [project](https://summerofcode.withgoogle.com/archive/2023/projects/Rkbc1Abe) ] [ [final report](https://cheskaqiqi.github.io/2023/08/22/Final/) ] [ [blog](https://cheskaqiqi.github.io/tags/GSoC/) ]
+2. Kousik Sanagavarapu [ [project](https://summerofcode.withgoogle.com/archive/2023/projects/rck3kmq2) ]  [ [final report](https://five-sh.github.io/2023/08/26/the-final-report) ] [ [blog](https://five-sh.github.io/blog) ]
 
 #### References
 
 - [GSoC archive](https://summerofcode.withgoogle.com/archive/2023/organizations/git)
+- [Rev News article](https://git.github.io/rev_news/2023/06/30/edition-100/)
 
 ### 2022
 
-*TODO*
+1. Shaoxuan Yuan [ [project](https://summerofcode.withgoogle.com/archive/2022/projects/hz4rcOUB) ] [ [final report](https://ffyuanda.github.io/blog/GSoC-final-blog/) ] [ [blog](https://ffyuanda.github.io/tags/#learn) ]
+2. Abhradeep Chakraborty [ [project](https://summerofcode.withgoogle.com/archive/2022/projects/UPtA6qdf) ]  [ [final report](https://medium.com/@abhra303/gsoc-final-report-feaaacfae737) ] [ [blog](https://medium.com/@abhra303) ]
 
 #### References
 
 - [GSoC archive](https://summerofcode.withgoogle.com/archive/2022/organizations/git)
+- [Rev News article](https://git.github.io/rev_news/2022/06/30/edition-88/)
+
 
 ### 2021
 
-*TODO*
+1. ZheNing Hu [ [project](https://summerofcode.withgoogle.com/archive/2021/projects/5443907994779648) ] [ [final report](https://github.com/adlternative/adlternative.github.io/blob/gh-pages/blogs/gsoc/GSOC-Git-Final-Blog.md) ] [ [blog](https://github.com/adlternative/adlternative.github.io/tree/gh-pages/blogs/gsoc/) ]
+2. Atharva Raykar [ [project](https://summerofcode.withgoogle.com/archive/2021/projects/5071550033690624) ] [ [final report](https://github.com/tfidfwastaken/gitnotes/blob/main/final-report.md) ] [ [blog](https://github.com/tfidfwastaken/gitnotes/tree/main) ]
 
 #### References
 
 - [GSoC archive](https://summerofcode.withgoogle.com/archive/2021/organizations/6398200235163648)
+- [Rev News article](https://git.github.io/rev_news/2021/05/27/edition-75/)
+
 
 ### 2020
 
-*TODO*
+1. Shourya Shukla [ [project](https://summerofcode.withgoogle.com/archive/2020/projects/4541259818991616) ] [ [final report](https://shouryashukla.blogspot.com/2020/08/the-final-report.html) ] [ [blog](https://shouryashukla.blogspot.com/search/label/GSoC) ]
+2. Abhishek Kumar [ [project](https://summerofcode.withgoogle.com/archive/2020/projects/6510085276172288) ] [ [final report](https://github.com/abhishekkumar2718/GSoC20/blob/master/README.md) ] [ [blog](https://abhishekkumar2718.github.io/gsoc/) ]
+3. Hariom Verma [ [project](https://summerofcode.withgoogle.com/archive/2020/projects/6123927484497920) ] [ [final report](https://harry-hov.github.io/blogs/posts/the-final-report) ] [ [blog](https://harry-hov.github.io/blogs/posts/) ]
+
 
 #### References
 
 - [GSoC archive](https://summerofcode.withgoogle.com/archive/2020/organizations/5445576591671296)
+- [Rev News article](https://git.github.io/rev_news/2020/05/28/edition-63/)
+
 
 ### 2019
 
@@ -92,35 +105,49 @@ to Git via GSoC.
 
 ### 2014
 
-*TODO*
+1. Tanay Abhra [ [project](https://www.google-melange.com/archive/gsoc/2014/orgs/git/projects/tanayabh.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+2. Fabian Ruch [ [project](https://www.google-melange.com/archive/gsoc/2014/orgs/git/projects/bafain.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+
 
 #### References
 
 - [GSoC archive](https://www.google-melange.com/archive/gsoc/2014/orgs/git)
+- [GSoC retrospective](https://public-inbox.org/git/vpqsik1yg1l.fsf@anie.imag.fr/)
+
 
 ### 2013
 
-*Did not participate*
+***Did not participate***
+
 
 ### 2012
 
-*TODO*
+1. Thomas Gummerer [ [project](https://www.google-melange.com/archive/gsoc/2012/orgs/git/projects/tgummerer.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Michael Schubert [ [project](https://www.google-melange.com/archive/gsoc/2012/orgs/git/projects/schu.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Florian Achleitner [ [project](https://www.google-melange.com/archive/gsoc/2012/orgs/git/projects/flyingflo.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
 
 #### References
 
 - [GSoC archive](https://www.google-melange.com/archive/gsoc/2012/orgs/git)
 
+
 ### 2011
 
-*TODO*
+1. Carlos Martín Nieto [ [project](https://www.google-melange.com/archive/gsoc/2011/orgs/git/projects/carlosmn.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Ramkumar Ramachandra [ [project](https://www.google-melange.com/archive/gsoc/2011/orgs/git/projects/artagnon.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Fredrik Gustafsson [ [project](https://www.google-melange.com/archive/gsoc/2011/orgs/git/projects/iveqy.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+
 
 #### References
 
 - [GSoC archive](https://www.google-melange.com/archive/gsoc/2011/orgs/git)
 
+
 ### 2010
 
-*TODO*
+1. Vicent Marti [ [project](https://www.google-melange.com/archive/gsoc/2010/orgs/git/projects/tanoku.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Ramkumar Ramachandra [ [project](https://www.google-melange.com/archive/gsoc/2010/orgs/git/projects/artagnon.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
+1. Bo Yang [ [project](https://www.google-melange.com/archive/gsoc/2010/orgs/git/projects/struggleyb.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
 
 #### References
 
@@ -128,8 +155,35 @@ to Git via GSoC.
 
 ### 2009
 
-*TODO*
+1. Nick Edelen [ [project](https://www.google-melange.com/archive/gsoc/2009/orgs/git/projects/sirnot.html) ] <!-- [ [final report]() ] [ [blog]() ] ] -->
 
 #### References
 
 - [GSoC archive](https://www.google-melange.com/archive/gsoc/2009/orgs/git)
+
+
+### 2008
+
+1. Joshua Roys (_project_: GitTorrent) [ [final e-mail](https://lore.kernel.org/git/48C05FB5.3010901@gmail.com/) ]
+2. Sverre Rabbelier (_project_: git-statistics) [ [final e-mail](https://lore.kernel.org/git/bd6139dc0809041544o427356c9i40a28b1c182817eb@mail.gmail.com/) ]
+3. Lea Wiemann (_project_: Gitweb caching) [ [idea discussion](https://lore.kernel.org/git/483C4CFF.2070101@gmail.com/#t) ]
+4. Marek Zawirski (_project_: Eclipse plugin push support) [ [final e-mail](https://lore.kernel.org/git/48C564ED.7050402@gmail.com/) ]
+5. Miklos Vajna (_project_: git-merge builtin) [ [final e-mail](https://lore.kernel.org/git/20080904225559.GP16514@genesis.frugalware.org/) ]
+6. Stephan Beyer (_project_: git-sequencer) [ [final e-mail](https://lore.kernel.org/git/20080904223653.GA15170@leksak.fem-net/) ]
+
+#### References
+
+- [GSoC archive](https://developers.google.com/open-source/gsoc/2008?csw=1#git-development-community)
+- [Mail about GSoC participant summary](https://lore.kernel.org/git/200809042315.58898.jnareb@gmail.com/)
+- [GSoC selection summary](https://lore.kernel.org/git/20080422013201.GA4828@spearce.org/)
+
+
+### 2007
+
+1. Carlos Rica (_project_: Shell script to C builtin conversions)
+2. Luiz Capitulino (_project_: Libification)
+
+#### References
+
+- [GSoC archive](https://developers.google.com/open-source/gsoc/2007?csw=1#git-development-community)
+- [GSoC report](https://lore.kernel.org/git/20070903034201.GP18160@spearce.org/)


### PR DESCRIPTION
This file is being collected to gather the information about the participants that have contributed to Git via GSoC, an outreach program conducted by Google each year. This would serve as a helpful reference.

The intention is not to restrict gathering the information only for GSoC. We've started gather this with GSoC. We'll expand to also gather information of participants who've contributed via Outreachy.

Related issue: #671 