### PR TITLE
microprojects: add notes for the 2025 microproject list

### DIFF
--- a/SoC-2025-Microprojects.md
+++ b/SoC-2025-Microprojects.md
@@ -206,3 +206,8 @@ There should be only one kind of change per commit. For example if one
 of your commits indents test bodies with TABs, instead of spaces, then
 this should be the only kind of change in this commit.
 
+#### Notes
+- only work on t/t????-*.sh scripts.
+- pick just one script (so as to avoid exhausting the pool for other candidates).
+- only convert `test -[def]` instances which semantically are assertions
+  (i.e. used as part of a &&-chain).


### PR DESCRIPTION
From an ongoing discussion on the mailing list [1], it would be nice to add some notes to the 'Modernize a test script' microproject. Let's do that.

[1]: https://lore.kernel.org/all/CAPig+cRm+sc+Rk-4SuQ5CrPeZLG2Nzz9B7+6OZxCq7tV5mzmBA@mail.gmail.com/