### PR TITLE
Rename references from *.txt to *.adoc in documentation paths.

### DIFF
--- a/Hacking-Git.md
+++ b/Hacking-Git.md
@@ -38,7 +38,7 @@ suggest improvements. Thanks!
 
 * ["My First Contribution"](https://git-scm.com/docs/MyFirstContribution)
 
-* ["My First Object Walk"](https://github.com/git/git/blob/master/Documentation/MyFirstObjectWalk.txt)
+* ["My First Object Walk"](https://github.com/git/git/blob/master/Documentation/MyFirstObjectWalk.adoc)
 
 * [Matheus' tutorial](https://matheustavares.gitlab.io/posts/first-steps-contributing-to-git)
 
@@ -102,7 +102,7 @@ suggest improvements. Thanks!
 
 * [`gitworkflows`](https://git-scm.com/docs/gitworkflows) manual page
 
-* ["How to maintain Git"](https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt)
+* ["How to maintain Git"](https://github.com/git/git/blob/master/Documentation/howto/maintain-git.adoc)
 
 * ["How the Creators of Git do Branching"](https://hackernoon.com/how-the-creators-of-git-do-branches-e6fcc57270fb), and the associated [gitworkflow](https://github.com/rocketraman/gitworkflow) repository
 

--- a/SoC-2019-Ideas.md
+++ b/SoC-2019-Ideas.md
@@ -137,7 +137,7 @@ See discussion in:
  - Possible mentors: Christian Couder, Thomas Gummerer
 
 A number of Git commands, like `git log`, can show commit information
-in a configurable way using ["pretty" formats](https://github.com/git/git/blob/master/Documentation/pretty-formats.txt).
+in a configurable way using ["pretty" formats](https://github.com/git/git/blob/master/Documentation/pretty-formats.adoc).
 Such formats though don't yet support some features that users would
 like, for example to display a log like the following:
 

--- a/SoC-2020-Ideas.md
+++ b/SoC-2020-Ideas.md
@@ -45,7 +45,7 @@ See discussion in:
 
 A number of Git commands, like `git log`, can show commit information
 in a configurable way using
-["pretty" formats](https://github.com/git/git/blob/master/Documentation/pretty-formats.txt).
+["pretty" formats](https://github.com/git/git/blob/master/Documentation/pretty-formats.adoc).
 Such formats though don't yet support some features that users would
 like, for example to display a log like the following:
 

--- a/SoC-2024-Ideas.md
+++ b/SoC-2024-Ideas.md
@@ -55,7 +55,7 @@ the reftable ones.
   - <https://lore.kernel.org/git/20240112102743.1440-1-ach.lumap@gmail.com/>
   - <https://lore.kernel.org/git/20240205162506.1835-1-ach.lumap@gmail.com/>
   - <https://lore.kernel.org/git/20240112102122.1422-1-ach.lumap@gmail.com/>
-  - <https://github.com/git/git/blob/master/Documentation/technical/unit-tests.txt>
+  - <https://github.com/git/git/blob/master/Documentation/technical/unit-tests.adoc>
 
 Expected Project Size: 175 hours or 350 hours
 
@@ -77,7 +77,7 @@ the new framework.
 See:
 
   - this discussion <https://lore.kernel.org/git/cover.1692297001.git.steadmon@google.com/>
-  - <https://github.com/git/git/blob/master/Documentation/technical/unit-tests.txt>
+  - <https://github.com/git/git/blob/master/Documentation/technical/unit-tests.adoc>
   - <https://git-scm.com/docs/reftable>
 
 Expected Project Size: 175 hours or 350 hours


### PR DESCRIPTION
Since the documentation in git is changed from *.txt to *.adoc format. Update references to reflect that change.