### PR TITLE
Rename references from *.txt to *.adoc in Rev News editions.

### DIFF
--- a/_posts/2015-08-05-edition-6.markdown
+++ b/_posts/2015-08-05-edition-6.markdown
@@ -25,7 +25,7 @@ Git 2.5 is out! The project maintainer, Junio C. Hamano, has [shared his thought
 
 He goes on to talk about some of his favourite new features included in the release, such as a new short hand `branch@{push}` that "denotes the remote-tracking branch that tracks the branch at the remote the branch would be pushed to", and a new option `--ws-error-highlight` that can be used with `git diff` and friends to show whitespace breakages in deleted and context lines.
 
-Be sure to see the post for more on the new features, or checkout the [release notes in the source](https://github.com/git/git/blob/master/Documentation/RelNotes/2.5.0.txt) for all the nitty gritty details.
+Be sure to see the post for more on the new features, or checkout the [release notes in the source](https://github.com/git/git/blob/master/Documentation/RelNotes/2.5.0.adoc) for all the nitty gritty details.
 
 
 ### Did you know?

--- a/_posts/2017-12-20-edition-34.markdown
+++ b/_posts/2017-12-20-edition-34.markdown
@@ -310,7 +310,7 @@ __Various__
   * [Git Essentials, 2nd Edition](https://www.packtpub.com/application-development/git-essentials-second-edition)
   * [Git: Version Control for Everyone](https://www.packtpub.com/application-development/git-version-control-everyone) (which was [reviewed](https://git-blame.blogspot.com/2013/02/git-version-control-for-everyone.html) by Junio C Hamano on his blog)
 * [Discussions on Hacker News](https://news.ycombinator.com/item?id=15819033)
-  about [the hash transition plan](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.txt).
+  about [the hash transition plan](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.adoc).
 * [Protecting code integrity with PGP](https://github.com/lfit/itpol/blob/master/protecting-code-integrity.md) (beta),
   part of Useful IT Policies project
 * [Effortlessly maintain a high quality change log with Git notes](https://harrow.io/blog/effortlessly-maintain-a-high-quality-change-log-with-little-known-git-tricks/) by Lee Hambley

--- a/_posts/2018-07-18-edition-41.markdown
+++ b/_posts/2018-07-18-edition-41.markdown
@@ -36,7 +36,7 @@ With Brian's latest patches Git would work using NewHash, including
 passing the test suite, though it would be incompatible with current
 Git.
 
-As the [hash function transition plan](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.txt)
+As the [hash function transition plan](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.adoc)
 tells that a Git using NewHash should be able to communicate through
 fetching and pushing with a Git using SHA-1, the next step is to
 implement such kind of communication and that's what Brian started to

--- a/_posts/2018-08-22-edition-42.markdown
+++ b/_posts/2018-08-22-edition-42.markdown
@@ -25,7 +25,7 @@ This edition covers what happened during the month of July 2018.
 discussed the state of NewHash work, i.e. the process of selecting
 Git's next-generation hash function. [This discussion has concluded](https://public-inbox.org/git/20180724190136.GA5@0f3cdde9c159/)
 with the selection of SHA-256. An
-[update to `hash-function-transition.txt` to change `NewHash` to `SHA-256`](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.txt)
+[update to `hash-function-transition.txt` to change `NewHash` to `SHA-256`](https://github.com/git/git/blob/master/Documentation/technical/hash-function-transition.adoc)
 is queued in the `next` branch.
 
 <!---

--- a/_posts/2018-11-21-edition-45.markdown
+++ b/_posts/2018-11-21-edition-45.markdown
@@ -106,7 +106,7 @@ This edition covers what happened during the month of October 2018.
 
 * [[RFC] Generation Number v2](https://public-inbox.org/git/86tvl0zhos.fsf@gmail.com/t/#u)
 
-  The [commit-graph](https://github.com/git/git/blob/master/Documentation/technical/commit-graph.txt)
+  The [commit-graph](https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc)
   file mechanism (see the description above) accelerates commit graph
   walks in the two following ways:
   

--- a/_posts/2019-06-28-edition-52.markdown
+++ b/_posts/2019-06-28-edition-52.markdown
@@ -29,7 +29,7 @@ This edition covers what happened during the month of May 2019.
   where Git's test suite spends its time.
 
   His script also uses the new
-  [Git Trace2 API](https://github.com/git/git/blob/master/Documentation/technical/api-trace2.txt)
+  [Git Trace2 API](https://github.com/git/git/blob/master/Documentation/technical/api-trace2.aodc)
   which has been developed mostly by Jeff Hostetler
   [starting nearly one year ago](https://public-inbox.org/git/20180713165621.52017-1-git@jeffhostetler.com/)
   and then through different versions:
@@ -104,7 +104,7 @@ This edition covers what happened during the month of May 2019.
 
 * [[PATCH 00/17] [RFC] Commit-graph: Write incremental files](https://public-inbox.org/git/6d9c0911-6f36-3fb7-2be9-2be9bc68fc69@gmail.com/t/)
 
-  The road to incremental serialized [commit-graph](https://github.com/git/git/blob/master/Documentation/technical/commit-graph.txt)
+  The road to incremental serialized [commit-graph](https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc)
   started with [an attempt to create commit-graph file format v2](https://public-inbox.org/git/pull.112.git.gitgitgadget@gmail.com/t/#u)
 
   > The commit-graph file format has some shortcomings that were discussed

--- a/_posts/2023-10-31-edition-104.markdown
+++ b/_posts/2023-10-31-edition-104.markdown
@@ -135,7 +135,7 @@ __Light reading__
   by Kristian Lumme on Tower’s blog.
 + [Measuring Git performance with OpenTelemetry](https://github.blog/2023-10-16-measuring-git-performance-with-opentelemetry/)
   by Jeff Hostetler on GitHub Blog.  It describes how to use open source
-  [Trace2](https://github.com/git/git/blob/master/Documentation/technical/api-trace2.txt)
+  [Trace2](https://github.com/git/git/blob/master/Documentation/technical/api-trace2.adoc)
   [receiver component (trace2receiver)](https://github.com/git-ecosystem/trace2receiver)
   and [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/)
   to capture and visualize telemetry from your Git commands.

--- a/_posts/2024-04-30-edition-110.markdown
+++ b/_posts/2024-04-30-edition-110.markdown
@@ -87,7 +87,7 @@ This edition covers what happened during the months of March and April 2024.
 
   Junio replied by summarizing the current process related to these
   descriptions and pointing to the
-  ["Documentation/howto/maintain-git.txt" file](https://github.com/git/git/blob/master/Documentation/howto/maintain-git.txt),
+  ["Documentation/howto/maintain-git.adoc" file](https://github.com/git/git/blob/master/Documentation/howto/maintain-git.adoc),
   which describes his workflow and says that maintaining these topic
   descriptions is his responsibility as the project maintainer. He
   then mentioned some downsides of giving that responsibility to the

--- a/_posts/2024-10-31-edition-116.markdown
+++ b/_posts/2024-10-31-edition-116.markdown
@@ -297,7 +297,7 @@ __Light reading__
   Learn how to use this command to make use of references
   for information dumping, statistics, and much more.
   Included in this article is use of the new `is-base` field name recently added in
-  [Git 2.47.0](https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.47.0.txt).
+  [Git 2.47.0](https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.47.0.adoc).
 + [Searching for and navigating Git commits](https://alexharri.com/blog/searching-and-navigating-git-commits)
   by Alex Harri on his blog.
 + [Why some of us like "interdiff" code review](https://gist.github.com/thoughtpolice/9c45287550a56b2047c6311fbadebed2)

--- a/_posts/2024-12-31-edition-118.markdown
+++ b/_posts/2024-12-31-edition-118.markdown
@@ -178,7 +178,7 @@ This edition covers what happened during the months of November and December 202
   (via comments in [`meson.build`](https://git.kernel.org/pub/scm/git/git.git/tree/meson.build))
   to help build Git with Meson and
   [a build system comparison](https://lore.kernel.org/git/20241206-pks-meson-v11-23-525ed4792b88@pks.im/#Z31Documentation:technical:build-systems.txt)
-  (in [`Documentation/technical/build-systems.txt`](https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/technical/build-systems.txt))
+  (in [`Documentation/technical/build-systems.txt`](https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/technical/build-systems.adoc))
   that might be interesting to read.
 
 


### PR DESCRIPTION
Since the documentation in git is changed from *.txt to *.adoc format. Update references in previous editions to reflect that change.