### PR TITLE
rn-124: add links to Git Merge speakers and schedule

### DIFF
--- a/rev_news/drafts/edition-124.md
+++ b/rev_news/drafts/edition-124.md
@@ -37,6 +37,8 @@ This edition covers what happened during the months of May 2025 and June 2025.
 
 __Various__
 
++ The Git Merge 2025 [speaker list](https://git-merge.com/#speakers)
+  and [schedule](https://git-merge.com/#schedule) have been announced.
 
 __Light reading__
 + [How to Install Gitea (with SQLite3 and HTTPS!) on a VPS](https://www.git-tower.com/blog/how-to-install-gitea)


### PR DESCRIPTION
As @leereilly suggested on https://github.com/git/git.github.io/issues/780#issuecomment-2988364164 it might be a good idea to mention that Git Merge 2025 speakers and schedule have been announced.

@leereilly, @jnareb please take a look.