### PR TITLE
Fix typo on Luca's name on edition-124.md

### DIFF
--- a/rev_news/drafts/edition-124.md
+++ b/rev_news/drafts/edition-124.md
@@ -29,9 +29,9 @@ This edition covers what happened during the months of May 2025 and June 2025.
 ### Support
 -->
 
-## Community Spotlight: Luca Milanesi
+## Community Spotlight: Luca Milanesio
 
-_Luca Milanesio is long standing contributor to both JGit and Gerrit
+_Luca Milanesio is a long standing contributor to both JGit and Gerrit
 Code Review, an open-source veteran who's been accelerating Git
 workflows for 30+ years—from founding GerritHub.io to pioneering
 AI-powered repository optimization research._


### PR DESCRIPTION
Amend Luca Milanesio's name in the community spotlight and fix a small typo associated with it.