### PR TITLE
Rev News edition 138: add crux to Other News

### DIFF
--- a/rev_news/drafts/edition-138.md
+++ b/rev_news/drafts/edition-138.md
@@ -46,6 +46,8 @@ __Easy watching__
 
 __Git tools and sites__
 
+* [crux](https://github.com/Emran-goat/crux) by Emran is a CLI that finds the exact commit which changed a program's behavior, then minimizes that commit down to the lines that caused the change. It handles cases git bisect can't: behaviors that aren't pass/fail tests, failures that need two commits together, and regressions caused by dependency updates. ([crates.io](https://crates.io/crates/crux-finder))
+
 
 ## Releases
 


### PR DESCRIPTION
Adds crux to the Other News, Git tools and sites section of the edition 138 draft.

crux is a CLI that finds the exact commit which changed a program's behavior, then minimizes that commit down to the lines that caused the change. It covers cases git bisect does not: behaviors that are not pass/fail, failures that need two commits together, and regressions from dependency updates.

Source: https://github.com/Emran-goat/crux