### PR TITLE
rn-138: add WebTerm Learn to Git tools and sites

### DIFF
--- a/rev_news/drafts/edition-138.md
+++ b/rev_news/drafts/edition-138.md
@@ -392,6 +392,15 @@ __Git tools and sites__
 + [`tuicr`](https://github.com/agavra/tuicr) is a code review TUI with vim keybindings.
   Export to GitHub, GitLab, Bitbucket, or clipboard.
   Written in Rust, under MIT license.
++ [WebTerm Learn](https://learn.webterm.app/en/courses/git-introduction): free Git courses
+  that run in a simulated terminal in the browser.
+  The exercises check the resulting repository state (index, branches, commits)
+  rather than the exact command typed, so equivalent commands are accepted.
+  Covers first commit through rebase, stash, cherry-pick, conflicts
+  and pull requests against a simulated remote.
+  The first lesson of each course needs no account; the rest need a free account.
+  Its sibling [WebTerm](https://webterm.app/) is a no-signup browser terminal
+  with short tutorials, including a set on Git troubleshooting.
 
 
 ## Releases


### PR DESCRIPTION
Adds WebTerm Learn to the "Git tools and sites" list in edition 138, with a one-line mention of its sibling sandbox webterm.app.

WebTerm Learn is a set of free Git courses that run in a simulated terminal in the browser; exercises are checked against the repository state rather than the command string. I built both, so please edit the wording freely or drop the entry if it does not fit the edition.